### PR TITLE
feat: document defunct scrapers with explicit errors

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -570,3 +570,9 @@ sync_remote_files <- function(raw = FALSE){
     }
   
 }
+
+stop_defunct_scraper <- function(url){
+    stop(paste0(
+        "This scraper is not currently functional. Please occasionally check ",
+        "the following URL to see if data may now be scraped: ", url))
+}

--- a/production/scrapers/oklahoma.R
+++ b/production/scrapers/oklahoma.R
@@ -22,8 +22,11 @@ sum_slashes <- function(col) {
     return(col)
 }
 
+oklahoma_pull <- function(x){
+    stop_defunct_scraper(x)
+}
+
 oklahoma_restruct <- function(ok_html){
-    NULL
     # p_elements <- ok_html %>%
     #     rvest::html_nodes("body") %>%
     #     rvest::html_nodes("p")
@@ -140,7 +143,7 @@ oklahoma_scraper <- R6Class(
             type = "html",
             jurisdiction = "state",
             # pull the JSON data directly from the API
-            pull_func = xml2::read_html,
+            pull_func = oklahoma_pull,
             # 
             restruct_func = oklahoma_restruct,
             # Rename the columns to appropriate database names and do some minor

--- a/production/scrapers/orleans_parish.R
+++ b/production/scrapers/orleans_parish.R
@@ -2,7 +2,8 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 orleans_parish_pull <- function(x){
-    get_latest_manual("Orleans Parish Jails")
+    stop_defunct_scraper(x)
+    #get_latest_manual("Orleans Parish Jails")
 }
 
 orleans_parish_restruct <- function(x){

--- a/production/scrapers/spokane_county.R
+++ b/production/scrapers/spokane_county.R
@@ -2,7 +2,8 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 spokane_county_pull <- function(x){
-    xml2::read_html(x)
+    stop_defunct_scraper(x)
+    #xml2::read_html(x)
 }
 
 spokane_county_restruct <- function(x){

--- a/production/scrapers/wyoming.R
+++ b/production/scrapers/wyoming.R
@@ -22,7 +22,10 @@ wyoming_extract <- function(x){
 #' 
 #' @name wyoming_scraper
 #' @description As of 11/20/20 Wyoming stopped reporting cumulative cases and
-#' only reports active resident cases.
+#' only reports active resident cases. Note that we only update Wyoming data if
+#' it is less than 7 days old. If WY hasnt produced a new data sheet after 7
+#' days then no data should be recorded by the scraper and this scraper should
+#' fail.
 #' \describe{
 #'   \item{Facility_Name}{The faciilty name.}
 #' }


### PR DESCRIPTION
Scrapers that are known to be non-operational such as New Orleans now explicitly fail with a message acknowledging this status.

```
ERROR [2021-01-04 10:26:00] [ERROR] This scraper is not currently functional. Please occasionally check the following URL to see if data may now be scraped: http://doc.publishpath.com/Default.aspx?shortcut=covid-19-stats-report

Compact call stack:
  1 oklahoma$pull_raw()
  2 generic_scraper.R#149: tryLog(self$raw_data <- self$pull_func(
  3 oklahoma.R#26: stop_defunct_scraper(x)
  4 utilities.R#575: stop(paste0("This scraper is not currently fu
```