### PR TITLE
Col name assertion

### DIFF
--- a/production/scrapers/sacramento_county_jail.R
+++ b/production/scrapers/sacramento_county_jail.R
@@ -17,14 +17,24 @@ sacramento_county_jail_extract <- function(x, exp_date = Sys.Date()){
     
     error_on_date(x$Date, exp_date)
     
+    check_names(x, c(`Cumulative Confirmed Cases - Both Jails`,
+                     `Active in Custody - Main Jail`,
+                     `Active in Custody - RCCC`,
+                     `Resolved`,
+                     Deaths,
+                     `Cumulative Tested - Both Jails`,
+                     `Total Population - Both Jails`))
+    
     x %>%
+        mutate(Residents.Active = 
+                   `Active in Custody - Main Jail` + `Active in Custody - RCCC`) %>% 
         select(
-            Residents.Confirmed = `Confirmed Cases`,
-            Residents.Active = `Active in Custody`,
+            Residents.Confirmed = `Cumulative Confirmed Cases - Both Jails`,
+            Residents.Active = Residents.Active,
             Residents.Recovered = `Resolved`,
             Residents.Deaths = Deaths,
-            Residents.Tadmin = `Cumulative Tested`,
-            Residents.Population = `Total Population`
+            Residents.Tadmin = `Cumulative Tested - Both Jails`,
+            Residents.Population = `Total Population - Both Jails`
             ) %>%
         mutate(Name = "SACRAMENTO COUNTY JAIL")
 }

--- a/production/scrapers/santa_clara_county_jail.R
+++ b/production/scrapers/santa_clara_county_jail.R
@@ -17,6 +17,11 @@ santa_clara_county_jail_extract <- function(x, exp_date = Sys.Date()){
     
     error_on_date(x$Date, exp_date)
     
+    check_names(x, c(`Cumulative Cases`,
+                     `Active Cases In Custody`,
+                     `Total Tests Completed`,
+                     `Incarcerated People In Custody`))
+    
     x %>%
         select(
             Residents.Confirmed = `Cumulative Cases`,

--- a/production/scrapers/santa_rita_jail.R
+++ b/production/scrapers/santa_rita_jail.R
@@ -16,6 +16,13 @@ santa_rita_jail_extract <- function(x, exp_date = Sys.Date()){
     
     error_on_date(x$Date, exp_date)
     
+    check_names(x, c(`Confirmed Cases`,
+                     `Active Cases In Custody`,
+                     `Resolved in Custody`,
+                     Deaths,
+                     `Cumulative Tested`,
+                     `Tests Pending`))
+    
     x %>%
         select(
             Residents.Confirmed = `Confirmed Cases`,


### PR DESCRIPTION
Updated CA jail scrapers with column name checks and updated Sacramento County Jail scraper with new column names. 

One note on Sacramento jails: there are now two jails within the county being reported, in addition to their combined totals. I chose to only grab the combined counts from the two jails. LMK if you think I should we should break these out though. 