### PR TITLE
Check credits after post_run

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -102,15 +102,24 @@ replace_os <- function(cell){
 }
 
 ## Function to Check credits usage
-check_credits <- function(api_key=NULL) {
+check_credits <- function(api_key=NULL, verbose=FALSE) {
     if(is.null(api_key)){
         api_key <- Sys.getenv("EXTRACTABLE_API_KEY")
     }
     
     validate_endpoint = 'https://validator.extracttable.com'
-    httr::content(httr::GET(
+    content <- httr::content(httr::GET(
         url = validate_endpoint, httr::add_headers(`x-api-key` = api_key)), 
         as = 'parsed', type = 'application/json')
+    
+    credits <- content[1]$usage$credits
+    used <- content[1]$usage$used
+    remaining <- credits - used 
+    
+    # By default: only throw a warning if remaining credits fall below 200 
+    if (remaining < 200) {warning(paste("Running low on ExtractTable credits. Remaining:", remaining))}
+  
+    if (verbose) {content}
 }
 
 Caps <- function(x) {

--- a/production/post_run.R
+++ b/production/post_run.R
@@ -7,3 +7,5 @@ sync_remote_files(TRUE)
 Sys.sleep(7*60)
 write_latest_data()
 
+# Warn if running low on ExtractTable credits 
+check_credits()


### PR DESCRIPTION
I ran out of ExtractTable credits mid-way through running the scrapers today, so I thought adding a check after each run might be useful so we can replenish when they run low instead of run dry? 

* I arbitrarily chose 200 as the threshold for low
* I can see how the default behavior of `check_credits` is now confusing (i.e. it does nothing if you're not running low), but I think the only reason you'd really ever want to run this is to find out whether you're running low or not? 