### PR TITLE
Incorporated diagnostics scripts

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -605,6 +605,23 @@ sync_remote_files <- function(raw = FALSE){
   
 }
 
+sync_diagnostic_files <- function() {
+    system(str_c(
+        "rsync --perms --chmod=u+rwx -rtvu --progress results/diagnostic_files/ ",
+        "ucla:/srv/shiny-server/scraper_data/diagnostic_files/"))
+}
+
+generate_diagnostics <- function() {
+    if (!dir.exists("./results/diagnostic_files/")) {
+        dir.create("./results/diagnostic_files/")
+    }
+  
+    date <- Sys.Date()
+    rmarkdown::render("./reports/post_diagnostics.Rmd", 
+                      output_file = paste0("../results/diagnostic_files/", date, "_post_diagnostics.html"), 
+                      quiet = TRUE)
+}
+
 stop_defunct_scraper <- function(url){
     stop(paste0(
         "This scraper is not currently functional. Please occasionally check ",

--- a/production/post_run.R
+++ b/production/post_run.R
@@ -3,6 +3,16 @@ rm(list=ls())
 library(tidyverse)
 source("./R/utilities.R")
 
+# Sync raw, extracted, and log files 
 sync_remote_files(TRUE)
 Sys.sleep(7*60)
+
+# Generate and sync diagnostics 
+generate_diagnostics()
+sync_diagnostic_files()
+
+# Write latest csv 
 write_latest_data()
+
+
+

--- a/reports/post_diagnostics.Rmd
+++ b/reports/post_diagnostics.Rmd
@@ -8,9 +8,6 @@ output:
 ---
 
 ```{r setup, include = F}
-# To Run: rmarkdown::render("prototyping/post_diagnostics.Rmd", 
-#                           output_file = "../results/log_files/post_diagnostics.html")
-
 library(behindbarstools)
 library(tidyverse)
 library(googlesheets4)
@@ -233,7 +230,6 @@ check %>%
     select(State, Name, Residents.Deaths, previous_death_value, change_in_deaths) %>% 
     kable(col.names = c("State", "Name", "Current Deaths", "Previous Deaths", "Change")) %>% 
     kable_styling(bootstrap_options = c("condensed", "striped")) %>% 
-    column_spec(2, border_right = "1px solid #d2d2d2") %>% 
     scroll_box(height = "250px")
 ```
 
@@ -246,11 +242,7 @@ check %>%
 **Did any facilities see a decrease in cumulative cases?**
 
 ``` {r echo = F}
-# Get date of last scrape, and the previous scrape to compare it to 
-date_last_scraped <- max(scrape_df$Date)
-date_before_last_scrape <- max(scrape_df$Date[scrape_df$Date != max(scrape_df$Date)])
-
-# Calculate change in deaths from previous date scraped
+# Calculate change in cumulative cases from previous date scraped
 check <- scrape_df %>%
     filter(Date == date_last_scraped | Date == date_before_last_scrape) %>%
     group_by(Name, State, Jurisdiction) %>%
@@ -268,7 +260,6 @@ check %>%
     arrange(cases_diff, State, Name) %>% 
     kable(col.names = c("State", "Name", "Current Cases", "Previous Cases", "Change")) %>% 
     kable_styling(bootstrap_options = c("condensed", "striped")) %>% 
-    column_spec(2, border_right = "1px solid #d2d2d2") %>% 
     scroll_box(height = "250px") 
 ```
 
@@ -283,7 +274,6 @@ check %>%
     arrange(deaths_diff, State, Name) %>% 
     kable(col.names = c("State", "Name", "Current Deaths", "Previous Deaths", "Change")) %>% 
     kable_styling(bootstrap_options = c("condensed", "striped")) %>% 
-    column_spec(2, border_right = "1px solid #d2d2d2") %>% 
     scroll_box(height = "250px") 
 ```
 


### PR DESCRIPTION
Adding the diagnostics script to the post-run pipeline. Generates the html and then pushes it to the server (e.g. [here](http://104.131.72.50:3838/scraper_data/diagnostic_files/2021-01-25_post_diagnostics.html)). 