### PR TITLE
Renamed NC active cases

### DIFF
--- a/production/scrapers/north_carolina.R
+++ b/production/scrapers/north_carolina.R
@@ -21,7 +21,7 @@ north_carolina_extract <- function(x){
             Residents.Confirmed = Positive,
             Residents.Negative = Negative,
             Residents.Recovered = PresumedRecovered,
-            Residents.Quarantine = ActiveCases
+            Residents.Active = ActiveCases
             ) %>%
         clean_scraped_df() %>%
         filter(Name != "Statewide Totals")


### PR DESCRIPTION
Per [NC DOC dashboard](https://www.ncdps.gov/our-organization/adult-correction/prisons/prisons-info-covid-19): 
> Active Cases – number of offenders in a state prison with current COVID-19 diagnosis.

We had been scraping this as `Residents.Quarantine`, but it seems like it should be `Residents.Active`? 
