### PR TITLE
Adding OH active cases

### DIFF
--- a/production/scrapers/ohio.R
+++ b/production/scrapers/ohio.R
@@ -59,7 +59,6 @@ ohio_extract <- function(x){
         clean_scraped_df() %>% 
         mutate(Residents.Deaths = Residents.Confirmed.Deaths + Resident.Probable.Deaths, 
                Residents.Confirmed = Residents.Active + Residents.Confirmed.Deaths + Residents.Recovered, 
-               Staff.Confirmed = Staff.Active + Staff.Deaths + Staff.Recovered, 
                Residents.Quarantine = Residents.Quarantine + Residents.Isolation) %>% 
         select(
             -Staff.Active, -Residents.Pending, -Residents.Isolation,

--- a/production/scrapers/ohio.R
+++ b/production/scrapers/ohio.R
@@ -71,8 +71,11 @@ ohio_extract <- function(x){
 #' @name ohio_scraper
 #' @description Data come from a pdf which is updated periodically. The link
 #' to the pdf itself does not change only the data within the pdf. We should be
-#' periodically checking to see i f alternative sources are available as the data
-#' collected are sometimes fickle.
+#' periodically checking to see if alternative sources are available as the data
+#' collected are sometimes fickle. Cumulative positive cases come from the sum of 
+#' Active + Recovered + Deaths. We're summing confirmed and probable deaths for 
+#' Residents.Deaths, but we're NOT including probable deaths in the Residents.Confirmed
+#' total. 
 #' \describe{
 #'   \item{Institution}{}
 #'   \item{Housing Type (cell, open bay, combo)}{}


### PR DESCRIPTION
Ohio's variable definitions are a little mEsSY to me ([link](https://coronavirus.ohio.gov/static/reports/DRCCOVID-19Information.pdf)), but I'm pretty sure this is right! 

The only new thing here is that I'm adding `Residents.Active`. The other updates are just making intermediate variable names more descriptive. 

Side note: we're consistently reporting ~1500 fewer cumulative resident cases than MP in Ohio. It almost seems like they're getting cumulative cases from Recovered + Quarantine...? Based on how staff is reported, I still think this should be Recovered + Active + Deaths though. 