### PR TITLE
Ohio vaccine data 

### DIFF
--- a/production/historical_scrape/README_historical.md
+++ b/production/historical_scrape/README_historical.md
@@ -6,11 +6,18 @@ In these cases we need to run a slightly different pipeline which utilizes the `
 
 To see an example of this, please view the file in `production/historical_scrape/historical_scrapers/historical_ice.R`. 
 
-**Note**: The historical scraper pipeline is completely separate form the normal scraper pipline. If you find a historical data source, a new scraper will need to be constructed and placed in `production/historical_scrape/historical_scrapers/` even if a scraper that is used in the main production line already exists for it. 
+**Note**: The historical scraper pipeline is completely separate from the normal scraper pipeline. If you find a historical data source, a new scraper will need to be constructed and placed in `production/historical_scrape/historical_scrapers/` even if a scraper that is used in the main production line already exists for it. 
 
 #### Instructions: 
 
 1. **Build scraper**: Add the scraper to `production/historical_scrape_historical_scrapers`. Each historical scraper needs a `pull`, `restruct`, and `extract` function, and each of these functions must include a date parameter (regardless of whether that parameter is actually used within the function). 
-2. **Create a config file**: Write a config file which is a csv with 2 columns. Scraper: a character column of a valid historical scraper. Date: YYYY-MM-DD date of which day to run the hsitorical scraper.  
-3. **Run historical pipeline**: Run the historical scrape pipeline by running `production/historical_scrape/main_historical.R --config path/to/config.csv` from the command line. This will populate the `results` directory with the raw, extracted, and log files. 
+2. **Create a config file**: Write a config file, which is a csv with 2 columns: 
+
+* `Scraper`: a character column of a valid historical scraper (e.g. `historical_ice_scraper`) 
+* `Date`: YYYY-MM-DD date of which day to run the historical scraper 
+3. **Run historical pipeline**: Run the historical scrape pipeline by running the following from the command line (assuming your config file is in the path given): 
+```
+RScript production/historical_scrape/main_historical.R --config production/historical_scrape/config.csv
+```
+This will populate the `results` directory with the raw, extracted, and log files. 
 4. **Sync files**: Sync your files with the remote database by calling `sync_remote_files(raw = TRUE)` within the console. 

--- a/production/historical_scrape/historical_scrapers/historical_ohio_vaccine.R
+++ b/production/historical_scrape/historical_scrapers/historical_ohio_vaccine.R
@@ -1,0 +1,78 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+historical_ohio_vac_pull <- function(x, date = NULL){
+    get_latest_manual("Ohio_Vaccine")
+}
+
+historical_ohio_vac_restruct <- function(x, date = NULL){
+    x %>%
+        rename(
+            Residents.Vadmin = "Inmates",
+            Staff.Vadmin = "Staff") 
+}
+
+historical_ohio_vac_extract <- function(x, date){
+    x %>%
+        mutate(Name = "STATEWIDE") %>% 
+        filter(Date == date) %>% 
+        select(-Date)
+}
+
+#' Scraper class for ice COVID data
+#' 
+#' @name historical_ice_scraper
+#' @description This scraper pulls html data from the ice page which reports on
+#' the variables listed below. Unlike all other scrapers their are total column
+#' values that we want to keep which do not corresponds to a state but rather
+#' ICE as a whole. In addition we have found that facility names frequently
+#' change and require updates to the facility spellings sheet. Dates for this
+#' scraper should correspond to all dates which are present in the github sheet
+#' columns where the data is being pulled up to when the main scraper started
+#' pulling ice data 2021-01-12.
+#' \describe{
+#'   \item{Facility}{The facility name}
+#'   \item{Confirmed cases currently under isolation}{Residents with active inf}
+#'   \item{Detainee deaths}{Resident deaths}
+#'   \item{Total confirmed COVID-19}{Residents cconfirmed cumulative}
+#'   \item{Detained Population}{Current Resident Population}
+#'   \item{Population Tested}{Tested}
+#' }
+
+historical_ohio_vac_scraper <- R6Class(
+    "historical_ohio_vac_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Ohio Department of Rehabilitation and Correction",
+            id = "historical_ohio_vac",
+            type = "manual",
+            state = "OH",
+            jurisdiction = "state",
+            pull_func = historical_ohio_vac_pull,
+            restruct_func = historical_ohio_vac_restruct,
+            extract_func = historical_ohio_vac_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction  = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    historical_ohio_vac <- historical_ohio_vac_scraper$new(log=TRUE)
+    historical_ohio_vac$reset_date("SET_DATE_HERE")
+    historical_ohio_vac$raw_data
+    historical_ohio_vac$pull_raw(date = scraper$date, .dated_pull = TRUE)
+    historical_ohio_vac$raw_data
+    historical_ohio_vac$save_raw()
+    historical_ohio_vac$restruct_raw(date = scraper$date)
+    historical_ohio_vac$restruct_data
+    historical_ohio_vac$extract_from_raw(date = scraper$date)
+    historical_ohio_vac$extract_data
+    historical_ohio_vac$validate_extract()
+    historical_ohio_vac$save_extract()
+}

--- a/production/historical_scrape/historical_scrapers/historical_ohio_vaccine.R
+++ b/production/historical_scrape/historical_scrapers/historical_ohio_vaccine.R
@@ -19,24 +19,15 @@ historical_ohio_vac_extract <- function(x, date){
         select(-Date)
 }
 
-#' Scraper class for ice COVID data
+#' Scraper class for Ohio vaccine data
 #' 
-#' @name historical_ice_scraper
-#' @description This scraper pulls html data from the ice page which reports on
-#' the variables listed below. Unlike all other scrapers their are total column
-#' values that we want to keep which do not corresponds to a state but rather
-#' ICE as a whole. In addition we have found that facility names frequently
-#' change and require updates to the facility spellings sheet. Dates for this
-#' scraper should correspond to all dates which are present in the github sheet
-#' columns where the data is being pulled up to when the main scraper started
-#' pulling ice data 2021-01-12.
+#' @name historical_ohio_vac_scraper
+#' @description This scraper pulls data from a manual csv file. We're receiving 
+#' vaccine data from the ODRC once/week via email. We're getting statewide totals
+#' for residents and staff. 
 #' \describe{
-#'   \item{Facility}{The facility name}
-#'   \item{Confirmed cases currently under isolation}{Residents with active inf}
-#'   \item{Detainee deaths}{Resident deaths}
-#'   \item{Total confirmed COVID-19}{Residents cconfirmed cumulative}
-#'   \item{Detained Population}{Current Resident Population}
-#'   \item{Population Tested}{Tested}
+#'   \item{Inmates}{Number of doses administered to incarcerated residents}
+#'   \item{Staff}{Number of doses administered to staff}
 #' }
 
 historical_ohio_vac_scraper <- R6Class(


### PR DESCRIPTION
Added a historical scraper for Ohio's vaccine data. It worked (i.e. produced raw and extracted data files that looked like they were supposed to), so that's neat. I also updated the instructions to clarify things that were confusing to me. A few notes: 
* Since we're getting this data via email, I just listed "Ohio Department of Rehabilitation and Correction" as the url?  
* Moving forward, do we want to keep Ohio (and North Carolina) vaccine data as historical scrapers? In both cases, we're getting vaccine data via email once/week. 
* I'll actually sync the data once this PR is approved. 