### PR TITLE
Updated all non-volunteer manual scrapers to Google Sheet

### DIFF
--- a/production/scrapers/north_carolina_vaccine.R
+++ b/production/scrapers/north_carolina_vaccine.R
@@ -1,0 +1,85 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+north_carolina_vaccine_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "NC Vaccine", 
+                                  col_types = "Dccc")
+}
+
+north_carolina_vaccine_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+north_carolina_vaccine_extract <- function(x, exp_date = Sys.Date()){
+    
+    error_on_date(first(x$Date), exp_date)
+    
+    check_names(x, c(
+        "Date", 
+        "Name", 
+        "Offenders", 
+        "Staff")
+    )
+    
+    x %>%
+        select(
+            Name = `Name`,
+            Residents.Initiated = `Offenders`,
+            Staff.Initiated = `Staff`) %>% 
+        clean_scraped_df()
+}
+
+#' Scraper class for North Carolina vaccine data 
+#' 
+#' @name north_carolina_vaccine_scraper
+#' @description Grabs manually entered Google Sheet data for NC vaccines. Raw data
+#' is received via email from the NC DOC weekly. Only statewide totals for incarcerated 
+#' people and staff are shared.  
+#' 
+#' \describe{
+#'   \item{Offenders}{Number of incarcerated residents who received first doses}
+#'   \item{Staff}{Number of staff who received first doses}
+#' }
+
+north_carolina_vaccine_scraper <- R6Class(
+    "north_carolina_vaccine_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "North Carolina Department of Public Safety",
+            id = "north_carolina_vaccine",
+            type = "manual",
+            state = "NC",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = north_carolina_vaccine_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = north_carolina_vaccine_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = north_carolina_vaccine_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    north_carolina_vaccine <- north_carolina_vaccine_scraper$new(log=TRUE)
+    north_carolina_vaccine$raw_data
+    north_carolina_vaccine$pull_raw()
+    north_carolina_vaccine$raw_data
+    north_carolina_vaccine$save_raw()
+    north_carolina_vaccine$restruct_raw()
+    north_carolina_vaccine$restruct_data
+    north_carolina_vaccine$extract_from_raw()
+    north_carolina_vaccine$extract_data
+    north_carolina_vaccine$validate_extract()
+    north_carolina_vaccine$save_extract()
+}

--- a/production/scrapers/ohio_vaccine.R
+++ b/production/scrapers/ohio_vaccine.R
@@ -1,0 +1,85 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+ohio_vaccine_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "OH Vaccine", 
+                                  col_types = "Dccc")
+}
+
+ohio_vaccine_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+ohio_vaccine_extract <- function(x, exp_date = Sys.Date()){
+    
+    error_on_date(first(x$Date), exp_date)
+    
+    check_names(x, c(
+        "Date", 
+        "Name", 
+        "Inmates", 
+        "Staff")
+    )
+    
+    x %>%
+        select(
+            Name = `Name`,
+            Residents.Vadmin = `Inmates`,
+            Staff.Vadmin = `Staff`) %>% 
+        clean_scraped_df()
+}
+
+#' Scraper class for Ohio vaccine data 
+#' 
+#' @name ohio_vaccine_scraper
+#' @description Grabs manually entered Google Sheet data for OH vaccines. Raw data
+#' is received via email from the Ohio DOC weekly. Only statewide totals for 
+#' incarcerated people and staff are shared.  
+#' 
+#' \describe{
+#'   \item{Inmates}{Cumulative 1st doses received by staff}
+#'   \item{Staff}{Cumulative 2nd doses received by staff}
+#' }
+
+ohio_vaccine_scraper <- R6Class(
+    "ohio_vaccine_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Ohio Department of Rehabilitation and Correction",
+            id = "ohio_vaccine",
+            type = "manual",
+            state = "OH",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = ohio_vaccine_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = ohio_vaccine_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = ohio_vaccine_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    ohio_vaccine <- ohio_vaccine_scraper$new(log=TRUE)
+    ohio_vaccine$raw_data
+    ohio_vaccine$pull_raw()
+    ohio_vaccine$raw_data
+    ohio_vaccine$save_raw()
+    ohio_vaccine$restruct_raw()
+    ohio_vaccine$restruct_data
+    ohio_vaccine$extract_from_raw()
+    ohio_vaccine$extract_data
+    ohio_vaccine$validate_extract()
+    ohio_vaccine$save_extract()
+}

--- a/production/scrapers/wyoming.R
+++ b/production/scrapers/wyoming.R
@@ -1,0 +1,84 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+wyoming_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "WY", 
+                                  col_types = "Dccc")
+}
+
+wyoming_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+wyoming_extract <- function(x, exp_date = Sys.Date()){
+    
+    error_on_date(first(x$Date), exp_date)
+    
+    check_names(x, c(
+        "Date", 
+        "Name", 
+        "Positive Inmate Cases", 
+        "Inmate Deaths")
+    )
+    
+    x %>%
+        select(
+            Name = `Name`,
+            Residents.Active = `Positive Inmate Cases`,
+            Residents.Deaths = `Inmate Deaths`) %>% 
+        clean_scraped_df()
+}
+
+#' Scraper class for Wyoming data 
+#' 
+#' @name wyoming_scraper
+#' @description Grabs manually entered Google Sheet data for Wyoming. Only active 
+#' cases and deaths are reported. 
+#' 
+#' \describe{
+#'   \item{Positive inmate cases}{Active cases among residents}
+#'   \item{Inmate deaths}{Cumulative COVID-19 deaths}
+#' }
+
+wyoming_scraper <- R6Class(
+    "wyoming_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "http://corrections.wyo.gov/",
+            id = "wyoming",
+            type = "manual",
+            state = "WY",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = wyoming_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = wyoming_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = wyoming_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    wyoming <- wyoming_scraper$new(log=TRUE)
+    wyoming$raw_data
+    wyoming$pull_raw()
+    wyoming$raw_data
+    wyoming$save_raw()
+    wyoming$restruct_raw()
+    wyoming$restruct_data
+    wyoming$extract_from_raw()
+    wyoming$extract_data
+    wyoming$validate_extract()
+    wyoming$save_extract()
+}


### PR DESCRIPTION
Added all non-volunteer manual scrapers to the Google Sheet process ([link to sheet](https://docs.google.com/spreadsheets/d/1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ/edit#gid=1527592402)). Opening a separate PR for Delaware and Vermont in a few. Also added a lot of documentation. 

I thought about to addding this to `generic_scraper.R` and then update the pull functions in the scrapers accordingly to avoid having random URLs in code, but curious what others thing: 
```
MANUAL_GOOGLE_SHEET_URL <- "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ"
```
Genuinely SO excited to never have to download manual files from Teams again before running the scrapers!!  