### PR TITLE
fix: RI, all deaths attributed to incarcerated population

### DIFF
--- a/production/scrapers/rhode_island.R
+++ b/production/scrapers/rhode_island.R
@@ -53,20 +53,26 @@ rhode_island_pull <- function(x){
 
 rhode_island_restruct <- function(x){
     x %>%
-        mutate(`Deaths` = string_to_clean_numeric(`Deaths`)) %>%
+        extract(`Deaths`, into = c("n_deaths", "death_group"), "([0-9]+)\\s+\\(([^)]+)") %>%
         mutate(`Facility staff` = string_to_clean_numeric(`Facility staff`)) %>%
         mutate(`Facility residents` = 
                    string_to_clean_numeric(`Facility residents`)) %>%
         filter(!is.na(`Facility residents`)) %>%
-        filter(!str_detect(Name, "(?i)total"))
+        filter(!str_detect(Name, "(?i)total")) %>%
+        mutate(Residents.Deaths = ifelse(str_detect(death_group, "(?i)inmate"), n_deaths, NA),
+               Residents.Deaths = string_to_clean_numeric(Residents.Deaths),
+               Staff.Deaths = ifelse(str_detect(death_group, "(?i)staff"), n_deaths, NA),
+               Staff.Deaths = string_to_clean_numeric(Staff.Deaths))
 }
 
 rhode_island_extract <- function(x){
     x %>%
         select(
-            Name, Residents.Confirmed = `Facility residents`,
+            Name, 
+            Residents.Confirmed = `Facility residents`,
             Staff.Confirmed = `Facility staff`,
-            Residents.Deaths = Deaths)
+            Residents.Deaths,
+            Staff.Deaths)
 }
 
 #' Scraper class for general rhode_island COVID data


### PR DESCRIPTION
Noting that this solution won't work for a situation when we have both staff and resident deaths listed in the same cell. For example:

```
x <- tibble(Deaths = "1 (inmate) 2 (staff)")
x %>%
    extract(`Deaths`, into = c("n_deaths", "death_group"), "([0-9]+)\\s+\\(([^)]+)")

```

But, since I don't believe we've seen this listed thus far for RI, I went for a simpler solution that distinguishes staff and resident deaths by the string inside the parentheses. 

```
x <- tibble(Deaths = "1 (inmate)")
x %>%
     extract(`Deaths`, into = c("n_deaths", "death_group"), "([0-9]+)\\s+\\(([^)]+)")

```
