### PR TITLE
Added vaccine vars to NA filter

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -531,27 +531,27 @@ sum_na_rm <- function(x){
 }
 
 write_latest_data <- function(coalesce = TRUE, fill = FALSE){
-    
-    rowAny <- function(x) rowSums(x) > 0
-    
-    covid_vars <- c(
-        "Residents.Confirmed", "Staff.Confirmed", "Residents.Deaths", "Staff.Deaths", 
-        "Residents.Recovered", "Staff.Recovered", "Residents.Tadmin", "Staff.Tested",  
-        "Residents.Negative", "Staff.Negative", "Residents.Pending", "Staff.Pending", 
-        "Residents.Quarantine", "Staff.Quarantine", "Residents.Active")
   
     out_df <- read_scrape_data(all_dates = FALSE, coalesce = TRUE)
     
+    covid_suffixes <- c(
+      ".Confirmed", ".Deaths", ".Recovered", ".Tadmin", ".Tested", ".Active",
+      ".Negative", ".Pending", ".Quarantine", ".Initiated", ".Completed", ".Vadmin")
+    
     out_df %>%
-        select(all_of(covid_vars)) %>%
+        select(all_of(ends_with(covid_suffixes))) %>%
         summarize_all(sum_na_rm) %>%
         pivot_longer(
-            Residents.Confirmed:Residents.Active, names_to = "Variable",
+            cols = everything(), 
+            names_to = "Variable",
             values_to = "Count") %>%
         print()
     
-      out_df %>%
-        filter(rowAny(across(covid_vars, ~ !is.na(.x)))) %>% 
+    rowAny <- function(x) rowSums(x) > 0
+    
+    out_df %>%
+        # Drop rows missing COVID data (e.g. only with population data)
+        filter(rowAny(across(ends_with(covid_suffixes), ~ !is.na(.x)))) %>% 
         select(
             Facility.ID, Jurisdiction, State, Name, Date, source,
             Residents.Confirmed, Staff.Confirmed,


### PR DESCRIPTION
Noticed a bug where we were dropping rows with statewide vaccine data (e.g. MA, NC, OH) because they didn't have other COVID variable data in `write_latest_data`. 