### PR TITLE
Add Iowa population scraper

### DIFF
--- a/production/historical_scrape/historical_scrapers/historical_iowa_population.R
+++ b/production/historical_scrape/historical_scrapers/historical_iowa_population.R
@@ -1,0 +1,90 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+historical_iowa_pop_pull <- function(x, file, date = NULL){
+    file %>% 
+        xml2::read_html()
+}
+
+historical_iowa_pop_restruct <- function(x, date = NULL){
+    x %>%
+        rvest::html_nodes("table") %>%
+        .[[1]] %>%
+        rvest::html_table(fill = TRUE)
+}
+
+historical_iowa_pop_extract <- function(x, date = NULL){
+    expected_names <- c(
+        "Institution", "Current Count", "Capacity", "Medical/Segregation")
+    
+    check_names(x, expected_names)
+    
+    x %>% 
+        select(Name = Institution, 
+               Residents.Population = `Current Count`) %>% 
+        filter(!Name %in% c("INSTITUTIONAL TOTALS", "% overcrowded by")) %>% 
+        # Rename and aggregate facility names to match COVID data 
+        mutate(Name = case_when(
+            # Report Live-Out separately, rename facility to denote this 
+            Name == "Minimum Live-Out" & lag(Name) == "Mitchellville" ~ "Mitchellville Minimum Live-Out", 
+            # Aggregate Oakdale with psychiatric hospital (IMCC in COVID data)
+            Name == "Forensic Psychiatric Hospital" & lag(Name) == "Oakdale" ~ "Oakdale", 
+            # Aggregate Newton medium and minimum  into Newton 
+            Name == "Minimum" & lag(Name) == "Newton-Medium" ~ "Newton", 
+            Name == "Newton-Medium" ~ "Newton", 
+            TRUE ~ Name)) %>% 
+        clean_scraped_df() %>% 
+        # Sum population across aggregated names 
+        group_by(Name) %>% 
+        summarise(Residents.Population = sum(Residents.Population)) %>% 
+        ungroup() 
+}
+
+#' Scraper class for Iowa population data
+#' 
+#' @name historical_iowa_population_scraper
+#' @description html table with minimal recoding and cleaning. Some name aggregating 
+#' to match how COVID data is reported. 
+#' \describe{
+#'   \item{Institution}{The faciilty name}
+#'   \item{Current Count}{Current population}
+#'   \item{Capacity}{Facility capacity}
+#'   \item{Medical/Segregation}{Population in medical care/segregation}
+#' }
+
+historical_iowa_pop_scraper <- R6Class(
+    "historical_iowa_pop_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://doc.iowa.gov/daily-statistics",
+            id = "historical_iowa_pop",
+            state = "IA",
+            type = "html",
+            jurisdiction = "state",
+            pull_func = historical_iowa_pop_pull,
+            restruct_func = historical_iowa_pop_restruct,
+            extract_func = historical_iowa_pop_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        })
+)
+
+if(sys.nframe() == 0){
+    historical_iowa_pop <- historical_iowa_pop_scraper$new(log=TRUE)
+    historical_iowa_pop$reset_date("DATE")
+    historical_iowa_pop$raw_data
+    historical_iowa_pop$pull_raw(file, .dated_pull = TRUE)
+    historical_iowa_pop$raw_data
+    historical_iowa_pop$save_raw()
+    historical_iowa_pop$restruct_raw()
+    historical_iowa_pop$restruct_data
+    historical_iowa_pop$extract_from_raw()
+    historical_iowa_pop$extract_data
+    historical_iowa_pop$validate_extract()
+    historical_iowa_pop$save_extract()
+}

--- a/production/scrapers/iowa_population.R
+++ b/production/scrapers/iowa_population.R
@@ -26,10 +26,11 @@ iowa_population_extract <- function(x){
         mutate(Name = case_when(
             # Report Live-Out separately, rename facility to denote this 
             Name == "Minimum Live-Out" & lag(Name) == "Mitchellville" ~ "Mitchellville Minimum Live-Out", 
-            # Report Psychiatric separately, rename facility to denote this 
-            Name == "Forensic Psychiatric Hospital" & lag(Name == "Oakdale") ~ "Oakdale Forensic Psychiatric Hospital", 
-            # Aggregate Newton medium and minimum  
-            Name == "Minimum" & lag(Name) == "Newton-Medium" ~ "Newton-Medium", 
+            # Aggregate Oakdale with psychiatric hospital (IMCC in COVID data)
+            Name == "Forensic Psychiatric Hospital" & lag(Name) == "Oakdale" ~ "Oakdale", 
+            # Aggregate Newton medium and minimum  into Newton 
+            Name == "Minimum" & lag(Name) == "Newton-Medium" ~ "Newton", 
+            Name == "Newton-Medium" ~ "Newton", 
             TRUE ~ Name)) %>% 
         clean_scraped_df() %>% 
         # Sum population across aggregated names 

--- a/production/scrapers/iowa_population.R
+++ b/production/scrapers/iowa_population.R
@@ -59,7 +59,7 @@ iowa_population_scraper <- R6Class(
         initialize = function(
             log,
             url = "https://doc.iowa.gov/daily-statistics",
-            id = "iowa",
+            id = "iowa_population",
             state = "IA",
             type = "html",
             jurisdiction = "state",

--- a/production/scrapers/iowa_population.R
+++ b/production/scrapers/iowa_population.R
@@ -1,0 +1,86 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+iowa_population_pull <- function(x){
+    xml2::read_html(x)
+}
+
+iowa_population_restruct <- function(x){
+    x %>%
+        rvest::html_nodes("table") %>%
+        .[[1]] %>%
+        rvest::html_table(fill = TRUE)
+}
+
+iowa_population_extract <- function(x){
+    expected_names <- c(
+        "Institution", "Current Count", "Capacity", "Medical/Segregation")
+    
+    check_names(x, expected_names)
+    
+    x %>% 
+        select(Name = Institution, 
+               Residents.Population = `Current Count`) %>% 
+        filter(!Name %in% c("INSTITUTIONAL TOTALS", "% overcrowded by")) %>% 
+        # Rename and aggregate facility names to match COVID data 
+        mutate(Name = case_when(
+            # Report Live-Out separately, rename facility to denote this 
+            Name == "Minimum Live-Out" & lag(Name) == "Mitchellville" ~ "Mitchellville Minimum Live-Out", 
+            # Report Psychiatric separately, rename facility to denote this 
+            Name == "Forensic Psychiatric Hospital" & lag(Name == "Oakdale") ~ "Oakdale Forensic Psychiatric Hospital", 
+            # Aggregate Newton medium and minimum  
+            Name == "Minimum" & lag(Name) == "Newton-Medium" ~ "Newton-Medium", 
+            TRUE ~ Name)) %>% 
+        clean_scraped_df() %>% 
+        # Sum population across aggregated names 
+        group_by(Name) %>% 
+        summarise(Residents.Population = sum(Residents.Population)) %>% 
+        ungroup() 
+}
+
+#' Scraper class for Iowa population data
+#' 
+#' @name iowa_population_scraper
+#' @description html table with minimal recoding and cleaning. Some name aggregating 
+#' to match how COVID data is reported. 
+#' \describe{
+#'   \item{Institution}{The faciilty name}
+#'   \item{Current Count}{Current population}
+#'   \item{Capacity}{Facility capacity}
+#'   \item{Medical/Segregation}{Population in medical care/segregation}
+#' }
+
+iowa_population_scraper <- R6Class(
+    "iowa_population_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://doc.iowa.gov/daily-statistics",
+            id = "iowa",
+            state = "IA",
+            type = "html",
+            jurisdiction = "state",
+            pull_func = iowa_population_pull,
+            restruct_func = iowa_population_restruct,
+            extract_func = iowa_population_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        })
+)
+
+if(sys.nframe() == 0){
+    iowa_population <- iowa_population_scraper$new(log = FALSE)
+    iowa_population$raw_data
+    iowa_population$pull_raw()
+    iowa_population$raw_data
+    iowa_population$restruct_raw()
+    iowa_population$restruct_data
+    iowa_population$extract_from_raw()
+    iowa_population$extract_data
+    iowa_population$validate_extract()
+    iowa_population$save_extract()
+}


### PR DESCRIPTION
Iowa reports daily population data in a little html table [here](https://doc.iowa.gov/daily-statistics), with [decent wayback coverage](https://web.archive.org/web/20200815000000*/https://doc.iowa.gov/daily-statistics) to retrospectively pull. 

The main issue is that the level of facility aggregation doesn't match the facility aggregation in the [COVID data](https://doc.iowa.gov/COVID19) (of course). 
* I left the live-out facilities (which I think means community supervision?) separate, but I could definitely be convinced against doing this. 
* I left the forensic psychiatric hospital separate, but I could again be convinced against doing this.  
* I grouped Newton Medium and Newton Minimum since there's just one Newton in the COVID data. 
* I double-checked that there's no double-counting (i.e. the total matches the sum of the facilities). 

There will also need to be more fac_spelling updates (literally always): 
* Mitchelville = ICIW
* Fort Madison = ISP
* Rockwell City = North Central 
* Oakdale = IMCC 