### PR TITLE
update: NH and AK vaccine scrapers

### DIFF
--- a/production/scrapers/alaska_vaccine.R
+++ b/production/scrapers/alaska_vaccine.R
@@ -1,0 +1,113 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+alaska_vaccine_pull <- function(x){
+    fprof <- RSelenium::makeFirefoxProfile(list(
+        browser.startup.homepage = "about:blank",
+        startup.homepage_override_url = "about:blank",
+        startup.homepage_welcome_url = "about:blank",
+        startup.homepage_welcome_url.additional = "about:blank",
+        browser.download.dir = "/home/seluser/Downloads",
+        browser.download.folderList = 2L,
+        browser.download.manager.showWhenStarting = FALSE,
+        browser.download.manager.focusWhenStarting = FALSE,
+        browser.download.manager.closeWhenDone = TRUE,
+        browser.helperApps.neverAsk.saveToDisk = 
+            "application/pdf, application/octet-stream",
+        pdfjs.disabled = TRUE,
+        plugin.scan.plid.all = FALSE,
+        plugin.scan.Acrobat = 99L))
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox",
+        extraCapabilities=fprof
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(x)
+    Sys.sleep(6)
+    
+    base_html <- remDr$getPageSource()
+    
+    xml2::read_html(base_html[[1]])
+}
+
+alaska_vaccine_restruct <- function(x){
+    vacc_tab <- x %>%
+        rvest::html_node("#vaccine_tracker") %>%
+        rvest::html_table()
+    
+    # remove the name columns
+    names(vacc_tab) <- unlist(vacc_tab[1,])
+    
+    as_tibble(vacc_tab[-1,])
+}
+
+alaska_vaccine_extract <- function(x){
+    x %>%
+        rename(
+            Name = Facility,
+            Residents.Vadmin = `Vax given`,
+            Residents.Initiated = `# individual inmates`,
+            Residents.Completed = `# completed series`) %>%
+        filter(!str_detect(Name, "(?i)total")) %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for general alaska_vaccine COVID data
+#' 
+#' @name alaska_vaccine_scraper
+#' @description Alaska vaccine data does not show up in the static html and
+#' needs to be loaded through selenium. Not sure why thats the case and cant
+#' tell where in the the network calls this is happening. Nevertheless, the
+#' data provided is detailed and covers all vars we want to report on.
+#' \describe{
+#'   \item{Facility_Name}{The facility name.}
+#'   \item{Vax given}{Residents.Vadmin}
+#'   \item{# individual inmates}{Residents.Initiated}
+#'   \item{# completed series}{Residents.Completed}
+#' }
+
+alaska_vaccine_scraper <- R6Class(
+    "alaska_vaccine_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://doc.alaska.gov/covid-19",
+            id = "alaska_vaccine",
+            type = "html",
+            state = "AK",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = alaska_vaccine_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = alaska_vaccine_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = alaska_vaccine_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    alaska_vaccine <- alaska_vaccine_scraper$new(log=TRUE)
+    alaska_vaccine$perma_save()
+    alaska_vaccine$raw_data
+    alaska_vaccine$pull_raw()
+    alaska_vaccine$raw_data
+    alaska_vaccine$save_raw()
+    alaska_vaccine$restruct_raw()
+    alaska_vaccine$restruct_data
+    alaska_vaccine$extract_from_raw()
+    alaska_vaccine$extract_data
+    alaska_vaccine$validate_extract()
+    alaska_vaccine$save_extract()
+}
+

--- a/production/scrapers/new_hampshire_vaccine.R
+++ b/production/scrapers/new_hampshire_vaccine.R
@@ -1,0 +1,101 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+new_hampshire_vaccine_pull <- function(x){
+    xml2::read_html(x)
+}
+
+new_hampshire_vaccine_restruct <- function(x){
+    tab_set <- x %>%
+        rvest::html_nodes(xpath="//table[@border=1]")
+    
+    captions <- tab_set %>%
+        rvest::html_text() %>%
+        clean_fac_col_txt()
+    
+    rez_vacc_idx <- which(
+        stringr::str_detect(captions, "(?i)resident") & 
+            stringr::str_detect(captions, "(?i)vaccine"))
+    
+    tab_set[[rez_vacc_idx]] %>%
+        rvest::html_table(header = FALSE) %>%
+        as_tibble()
+}
+
+new_hampshire_vaccine_extract <- function(x){
+    long_df <- x[,1:3] %>%
+        bind_rows(rename(x[,4:6], X1 = X4, X2 = X5, X3 = X6)) %>%
+        as_tibble()
+    
+    if(!any(str_detect(long_df$X1, "(?i)phase"))){
+        stop("html is not as expected please inspect")
+    }
+    
+    if(!any(str_detect(long_df$X2, "(?i)1st Dose"))){
+        stop("html is not as expected please inspect")
+    }
+    
+    if(!any(str_detect(long_df$X3, "(?i)2nd Dose"))){
+        stop("html is not as expected please inspect")
+    }
+    
+    long_df %>%
+        rename(Name = X1, Residents.Initiated = X2) %>%
+        rename(Residents.Completed = X3) %>%
+        filter(!str_detect(Name, "(?i)total")) %>%
+        filter(!str_detect(Name, "(?i)phase")) %>%
+        clean_scraped_df() %>%
+        group_by(Name) %>%
+        summarize_all(sum_na_rm)
+}
+
+#' Scraper class for general New Hampshire COVID data
+#' 
+#' @name new_hampshire_vaccine_scraper
+#' @description NH has 3 tables of data and the third one is related to
+#' vaccinations of residents. The table is broken down into phases which we
+#' are not extracting and break down vaccines by facility and initiated and
+#' completed.
+#' \describe{
+#'   \item{Facility_Name}{The facility name.}
+#'   \item{1st Dose}{Residents.Initiated}
+#'   \item{2nd Dose}{Residents.Completed}
+#' }
+
+new_hampshire_vaccine_scraper <- R6Class(
+    "new_hampshire_vaccine_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.covid19.nhdoc.nh.gov/covid-19-testing-information",
+            id = "new_hampshire_vaccine",
+            type = "html",
+            state = "NH",
+            jurisdiction = "state",
+            pull_func = new_hampshire_vaccine_pull,
+            restruct_func = new_hampshire_vaccine_restruct,
+            extract_func = new_hampshire_vaccine_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    new_hampshire_vaccine <- new_hampshire_vaccine_scraper$new(log=TRUE)
+    new_hampshire_vaccine$raw_data
+    new_hampshire_vaccine$pull_raw()
+    new_hampshire_vaccine$raw_data
+    new_hampshire_vaccine$save_raw()
+    new_hampshire_vaccine$restruct_raw()
+    new_hampshire_vaccine$restruct_data
+    new_hampshire_vaccine$extract_from_raw()
+    new_hampshire_vaccine$extract_data
+    new_hampshire_vaccine$validate_extract()
+    new_hampshire_vaccine$save_extract()
+}
+

--- a/production/scrapers/new_hampshire_vaccine.R
+++ b/production/scrapers/new_hampshire_vaccine.R
@@ -46,7 +46,8 @@ new_hampshire_vaccine_extract <- function(x){
         filter(!str_detect(Name, "(?i)phase")) %>%
         clean_scraped_df() %>%
         group_by(Name) %>%
-        summarize_all(sum_na_rm)
+        summarize_all(sum_na_rm) %>%
+        mutate(Residents.Vadmin = Residents.Initiated + Residents.Completed)
 }
 
 #' Scraper class for general New Hampshire COVID data


### PR DESCRIPTION
Sorry for the delay on this I couldnt figure out where AK vaccine data was coming from as `xml2::read_html`was not capturing the table and had to resort to selenium. Despite it being more intense to scrape AK is reporting data on all three of the variables that we collect vaccine data for at the facility level! NH is also reporting data at the facility level for initiated and completed and for now im going to add those two numbers together for completed as it looks like they are only reporting for two dose vaccination series though I expect this might change in the near future.

![2021-03-09-102331_822x199_scrot](https://user-images.githubusercontent.com/5198764/110497772-c317e300-80c4-11eb-8967-c49db6295691.png)
