### PR TITLE
update: add date check to mississippi

### DIFF
--- a/production/scrapers/mississippi.R
+++ b/production/scrapers/mississippi.R
@@ -5,8 +5,15 @@ mississippi_pull <- function(x){
     get_src_by_attr(x, "a", attr="href", attr_regex = "(?i)cases")
 }
 
-mississippi_restruct <- function(x){
+mississippi_restruct <- function(x, exp_date = Sys.Date()){
     ms_pgs <- magick::image_read_pdf(x)
+    
+    date <- magick::image_crop(ms_pgs, "1000x200+400+2700") %>% 
+        magick::image_ocr() %>% 
+        lubridate::mdy()
+    
+    error_on_date(date, exp_date)
+    
     ExtractTable(ms_pgs)
 }
 


### PR DESCRIPTION
Mississippi didn't update their PDF from 2/11 until 3/15.... and then updated again on 3/16??  

Gonna choose to believe that our scorecards leaked and that inspired their change in update frequency, but here's a little date check incase they go back to not updating again! 