### PR TITLE
feat: add connecticut population scrapers

### DIFF
--- a/production/historical_scrape/historical_scrapers/historical_connecticut_population.R
+++ b/production/historical_scrape/historical_scrapers/historical_connecticut_population.R
@@ -1,0 +1,55 @@
+# Connecticut's DOC posts facility-level population data on the state's open 
+# data portal. This script extracts ALL data since 2020-01-01 into a single 
+# cleaned csv file. See main connecticut_population scraper for more detailed 
+# documentation. 
+
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+write_to_server <- FALSE
+
+raw <- read_csv("https://data.ct.gov/api/views/n8x6-s299/rows.csv", 
+         col_types = "ccccc") %>% 
+    mutate(Date = lubridate::mdy(Date)) %>% 
+    filter(Date >= as.Date("2020-01-01"))
+
+check_names(raw, c(
+    "Date", 
+    "Facility Name",  
+    "Accused/Other Status Count", 
+    "Sentenced Status Count", 
+    "Total Facility Population Count"
+))
+
+out <- raw %>% 
+    select(
+        "Name" = "Facility Name", 
+        "Residents.Population" = "Total Facility Population Count", 
+        Date
+    ) %>% 
+    clean_scraped_df() %>% 
+    
+    # Aggregate names to match COVID data reporting 
+    mutate(
+        Name = clean_fac_col_txt(Name, to_upper = TRUE), 
+        Name = case_when(str_detect(Name, "MACDOUGALL|WALKER") ~ "MACDOUGALL WALKER", 
+                         str_detect(Name, "CORRIGAN|RADGOWSKI") ~ "CORRIGAN RADGOWSKI", 
+                         TRUE ~ Name)
+    ) %>% 
+    group_by(Name, Date) %>% 
+    summarise(Residents.Population = sum_na_rm(Residents.Population)) %>% 
+    ungroup() %>%
+    
+    # Add scraper columns 
+    mutate(
+        State = "CA", 
+        id = "historical_ct_pop", 
+        jurisdiction = "state", 
+        source = stringr::str_c("https://data.ct.gov/Public-Safety/", 
+                                "Correctional-Facility-Daily-Population-Count-By-Fa/n8x6-s299")
+    )
+    
+if (write_to_server){
+    write_csv(out, "results/extracted_data/historical_ct_pop.csv") 
+    sync_remote_files()
+}

--- a/production/historical_scrape/historical_scrapers/historical_connecticut_population.R
+++ b/production/historical_scrape/historical_scrapers/historical_connecticut_population.R
@@ -42,7 +42,7 @@ out <- raw %>%
     
     # Add scraper columns 
     mutate(
-        State = "CA", 
+        State = "CT", 
         id = "historical_ct_pop", 
         jurisdiction = "state", 
         source = stringr::str_c("https://data.ct.gov/Public-Safety/", 

--- a/production/scrapers/connecticut_population.R
+++ b/production/scrapers/connecticut_population.R
@@ -1,0 +1,96 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+connecticut_population_pull <- function(x){
+    read_csv("https://data.ct.gov/api/views/n8x6-s299/rows.csv", 
+             col_types = "ccccc") %>% 
+        mutate(Date = lubridate::mdy(Date))
+}
+
+connecticut_population_restruct <- function(x){
+    x %>% 
+        filter(Date == max(Date, na.rm = TRUE))
+}
+
+connecticut_population_extract <- function(x, exp_date = Sys.Date()){
+    
+    error_on_date(first(x$Date), exp_date, 30)
+    
+    check_names(x, c(
+        "Date", 
+        "Facility Name",  
+        "Accused/Other Status Count", 
+        "Sentenced Status Count", 
+        "Total Facility Population Count"
+    ))
+    
+    x %>% 
+        select(
+            "Name" = "Facility Name", 
+            "Residents.Population" = "Total Facility Population Count"
+        ) %>% 
+        clean_scraped_df() %>% 
+        
+        # Aggregate names to match COVID data reporting 
+        mutate(
+            Name = clean_fac_col_txt(Name, to_upper = TRUE), 
+            Name = case_when(str_detect(Name, "MACDOUGALL|WALKER") ~ "MACDOUGALL WALKER", 
+                             str_detect(Name, "CORRIGAN|RADGOWSKI") ~ "CORRIGAN RADGOWSKI", 
+                             TRUE ~ Name)
+        ) %>% 
+        group_by(Name) %>% 
+        summarise(Residents.Population = sum_na_rm(Residents.Population)) %>% 
+        ungroup() 
+}
+
+#' Scraper class for Connecticut population data 
+#' 
+#' @name connecticut_population_scraper
+#' @description Connecticut's DOC posts facility-level population data on the 
+#' state's open data portal. There's some facility name aggregation necessary to 
+#' match how the DOC reports COVID data. The portal shows that it's updated 
+#' almost daily, although the most recent date is almost a month old. 
+#' \describe{
+#'   \item{Date}{}
+#'   \item{Facility Name}{Name}
+#'   \item{Accused/Other Status Count}{}
+#'   \item{Sentenced Status Count}{}
+#'   \item{Total Facility Population Count}{Residents.Population}
+#' }
+
+connecticut_population_scraper <- R6Class(
+    "connecticut_population_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://data.ct.gov/Public-Safety/Correctional-Facility-Daily-Population-Count-By-Fa/n8x6-s299",
+            id = "connecticut_population",
+            type = "csv",
+            state = "CT",
+            jurisdiction = "state",
+            pull_func = connecticut_population_pull,
+            restruct_func = connecticut_population_restruct,
+            extract_func = connecticut_population_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction  = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    connecticut_population <- connecticut_population_scraper$new(log=TRUE)
+    connecticut_population$raw_data
+    connecticut_population$pull_raw()
+    connecticut_population$raw_data
+    connecticut_population$save_raw()
+    connecticut_population$restruct_raw()
+    connecticut_population$restruct_data
+    connecticut_population$extract_from_raw()
+    connecticut_population$extract_data
+    connecticut_population$validate_extract()
+    connecticut_population$save_extract()
+}


### PR DESCRIPTION
The CT DOC posts daily population data on the state's [open data portal](https://data.ct.gov/Public-Safety/Correctional-Facility-Daily-Population-Count-By-Fa/n8x6-s299) (yay!), BUT it seems like they only update this a month or so ex-post. 

The way I set it up now is to have: 
* A script that pulls all historical data after Jan 2020 that'll I'll run just one time 
* A regular scraper that pulls the latest date's data, but errors if this date is more than 30 days old (vs. the typical 7) 

Not totally sure if this approach is the best / extremely open to other suggestions! 

Also, I just pull from the csv on the portal (rather than use the actual Socrata API) to avoid having to deal with another set of tokens/dependencies – not committed to this either though! Also, TIL that `RSocrata` is personally maintained by the City of Chicago's CDO, which I think is neat. 