### PR TITLE
feat: add california vaccine scraper

### DIFF
--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -15,7 +15,8 @@ UCLABB_MAIN_VARIABLES <- c(
     "Residents.Population", "Residents.Active",
     "Staff.Vadmin", "Residents.Vadmin",
     "Staff.Initiated", "Residents.Initiated",
-    "Staff.Completed", "Residents.Completed"
+    "Staff.Completed", "Residents.Completed", 
+    "Staff.Population"
 )
 
 generic_scraper <- R6Class(

--- a/production/scrapers/california_population.R
+++ b/production/scrapers/california_population.R
@@ -2,26 +2,7 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 california_population_pull <- function(x){
-    
-    # Extract all URLs
-    url_ <- x %>% 
-        xml2::read_html() %>%
-        rvest::html_nodes("a") %>%
-        rvest::html_attr("href")
-    
-    # Extract all link texts
-    link_ <- x %>%
-        xml2::read_html() %>%
-        rvest::html_nodes("a") %>%
-        rvest::html_text()
-    
-    # Return URL for latest population pdf 
-    stringr::str_c(
-        "https://www.cdcr.ca.gov/", 
-        tibble(link = link_, url = url_) %>% 
-            filter(link == "View Weekly Report (Wednesday Reporting Date)") %>% 
-            pull(url)
-    )
+    stop_defunct_scraper(x)
 }
 
 california_population_restruct <- function(x, exp_date = Sys.Date()){

--- a/production/scrapers/california_vaccine.R
+++ b/production/scrapers/california_vaccine.R
@@ -2,9 +2,7 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 california_vaccine_pull <- function(x){
-    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
-        googlesheets4::read_sheet(sheet = "CA Vaccine", 
-                                  col_types = "Dccc")
+    stop_defunct_scraper(x)
 }
 
 california_vaccine_restruct <- function(x){

--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -138,7 +138,7 @@ california_vaccine_bi_restruct <- function(x){
             if(j == 2){
                 s_tab <- get_california_vaccine_bi_table(z, 2) %>%
                     rename("Name" = "Institution", 
-                           "Drop.Staff.Population" = "Current Population", 
+                           "Staff.Population" = "Current Population", 
                            "Staff.Initiated" = "Partially Vaccinated", 
                            "Staff.Completed" = "Fully Vaccinated") %>%
                     select(Name, starts_with("Staff"))
@@ -216,8 +216,8 @@ if(sys.nframe() == 0){
     california_bi_vaccine <- california_vaccine_bi_scraper$new(log=TRUE)
     california_bi_vaccine$raw_data
     california_bi_vaccine$pull_raw()
-    california_bi_vaccine$save_raw()
     california_bi_vaccine$raw_data
+    california_bi_vaccine$save_raw()
     california_bi_vaccine$restruct_raw()
     california_bi_vaccine$restruct_data
     california_bi_vaccine$extract_from_raw()

--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -1,0 +1,142 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+california_vaccine_bi_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>% 
+        str_c(
+            "eyJrIjoiODBjZjExNDktYWUxNi00NmM1LTllODMtY2VkMDM1MjlkODRiIiwidCI", 
+            "6IjA2NjI0NzdkLWZhMGMtNDU1Ni1hOGY1LWMzYmM2MmFhMGQ5YyJ9&", 
+            "pageName=ReportSection1d82f52cafdcc3e76847")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    xml2::read_html(remDr$getPageSource()[[1]])
+}
+
+get_california_vaccine_bi_table <- function(x, idx){
+    tab <- x %>%
+        rvest::html_nodes(".tableEx") %>%
+        # Assumes first table is incarcerated people, second is staff 
+        # Should check this in a better way 
+        .[idx] %>% 
+        rvest::html_node(".innerContainer")
+    
+    col_dat <- tab %>%
+        rvest::html_node(".bodyCells") %>%
+        rvest::html_node("div") %>%
+        rvest::html_children()
+    
+    # This is only returning the first 20 rows for some reason??  
+    dat_df <- do.call(rbind, lapply(col_dat, function(p){
+        sapply(rvest::html_children(p), function(z){
+            z %>% 
+                rvest::html_nodes("div") %>%
+                rvest::html_attr("title")})})) %>%
+        as.data.frame()
+    
+    names(dat_df) <- tab %>%
+        rvest::html_node(".columnHeaders") %>%
+        rvest::html_node("div") %>%
+        rvest::html_nodes("div") %>% 
+        rvest::html_attr("title") %>%
+        na.omit() %>%
+        as.vector()
+    
+    dat_df
+}
+
+california_vaccine_bi_restruct <- function(x){
+    res_tab <- get_california_vaccine_bi_table(x, 1) %>%
+        rename("Name" = "Institution", 
+               "Residents.Population" = "Current Population", 
+               "Residents.Initiated" = "Partially Vaccinated", 
+               "Residents.Completed" = "Fully Vaccinated") %>%
+        select(Name, starts_with("Res"))
+    
+    staff_tab <- get_california_vaccine_bi_table(x, 2) %>%
+        rename("Name" = "Institution", 
+               "Drop.Staff.Population" = "Current Population", 
+               "Staff.Initiated" = "Partially Vaccinated", 
+               "Staff.Completed" = "Fully Vaccinated") %>%
+        select(Name, starts_with("Staff"))
+    
+    full_join(res_tab, staff_tab, by = "Name") 
+}
+
+
+california_vaccine_bi_extract <- function(x){
+    x %>% 
+        mutate_at(vars(-Name), string_to_clean_numeric) %>% 
+        as_tibble() %>% 
+        clean_scraped_df()
+}
+
+#' Scraper class for general California vaccine COVID data from dashboard
+#' 
+#' @name california_vaccine_bi_scraper
+#' @description California vaccine and population data scraped from rendered 
+#' power BI iframe. All variables (including population) are reported for 
+#' incarcerated people and staff. 
+#' 
+#' Dashboard says "Reported vaccination rates for staff may underrepresent actual 
+#' vaccination rates, as personnel may receive vaccinations from community health 
+#' providers and are not required to report vaccination status". Dashboard also 
+#' says data updated once/day at 9am. 
+#' 
+#' \describe{
+#'   \item{Institution Name}{}
+#'   \item{Current Population}{}
+#'   \item{Partially Vaccinated}{}
+#'   \item{Fully Vaccinated}{}
+#'   \item{% Fully Vaccinated}{}
+#' }
+
+california_vaccine_bi_scraper <- R6Class(
+    "california_vaccine_bi_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cdcr.ca.gov/covid19/updates/",
+            id = "california_vaccine_bi",
+            type = "html",
+            state = "CA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = california_vaccine_bi_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = california_vaccine_bi_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = california_vaccine_bi_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    california_bi_vaccine <- california_vaccine_bi_scraper$new(log=TRUE)
+    california_bi_vaccine$raw_data
+    california_bi_vaccine$pull_raw()
+    california_bi_vaccine$raw_data
+    california_bi_vaccine$restruct_raw()
+    california_bi_vaccine$restruct_data
+    california_bi_vaccine$extract_from_raw()
+    california_bi_vaccine$extract_data
+    california_bi_vaccine$validate_extract()
+    california_bi_vaccine$save_extract()
+}
+


### PR DESCRIPTION
Opening this up as a draft PR because I need help! See comments below. 

Also, California report facility-level staff population data here, which I feel like would be really useful to collect for various analyses. Thoughts on adding it to the list of variables we scrape (even if we don't add it to GitHub/the Google Sheet, etc.)? 