### PR TITLE
OR, ND bug fixes

### DIFF
--- a/production/scrapers/north_dakota.R
+++ b/production/scrapers/north_dakota.R
@@ -76,7 +76,7 @@ north_dakota_extract <- function(x){
             Name, Residents.Confirmed, Residents.Recovered, Residents.Deaths,
             Staff.Confirmed, Staff.Recovered, Staff.Deaths,
             Residents.Tadmin = Residents.Total.Tests.Administered,
-            Staff.Tested = Staff.Total.Tests.Administered, 
+            Staff.Tested = Staff.Total.Individials.Tested, 
             Residents.Initiated = Residents.First.Dose, 
             Residents.Completed = Residents.Second.Dose
         ) %>% 

--- a/production/scrapers/oregon.R
+++ b/production/scrapers/oregon.R
@@ -36,10 +36,13 @@ oregon_extract <- function(x){
                Residents.Recovered = "Total AICs Recovered",
                Residents.Negative = "AIC Negatives to Date",
                Residents.Active = "Current AIC Active Cases",
-               Residents.Deaths = "AIC Deaths") %>%
+               Residents.Deaths = "AIC Deaths",
+               Residents.Tested = Residents.Confirmed + Residents.Negative
+               ) %>%
         clean_scraped_df() %>%
         mutate(Staff.Confirmed =
                    ifelse(Name == "State-Wide", NA, Staff.Confirmed)) %>%
+        # doing this because Residents.Confirmed = positive tests, not positive cases (?)
         mutate(Residents.Confirmed =
                    ifelse(Name == "State-Wide", NA, Residents.Confirmed)) %>%
         mutate(Residents.Negative =

--- a/production/scrapers/oregon_testing.R
+++ b/production/scrapers/oregon_testing.R
@@ -2,6 +2,7 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 oregon_testing_pull <- function(x){
+    stop_defunct_scraper(x)
     
     app_url <- "https://public.tableau.com/views/ODOCCovid-19TestResultDates" %>%
         str_c(


### PR DESCRIPTION
Thanks to Erika for finding these issues: 

https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/162
https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/143

For Oregon, `Staff.Tested` will go away because previously we counted `Staff.Confirmed` as `Staff.Tested`. 

I am curious why the "State-Wide" counts in Oregon were made to be NA. I thought about un-commenting them but figured there's probably a good reason for doing so. Anyone know? 





