### PR TITLE
fix: update tennessee NAs

### DIFF
--- a/production/scrapers/tennessee.R
+++ b/production/scrapers/tennessee.R
@@ -34,7 +34,9 @@ tennessee_extract <- function(x){
         filter(!str_detect(Name, "(?i)region|managed|location|total")) %>%
         filter(Name != "") %>%
         clean_scraped_df() %>%
-        as_tibble()
+        as_tibble() %>% 
+        mutate(Residents.Deaths = ifelse(
+            is.na(Residents.Deaths), 0, Residents.Deaths)) 
     
     col_name_mat2 <- matrix(c(
         "Name", "V1", "TESTING NUMBERS",
@@ -54,8 +56,6 @@ tennessee_extract <- function(x){
         clean_scraped_df() %>%
         as_tibble() %>%
         full_join(fac_df, by = "Name") %>%
-        mutate(Residents.Deaths = ifelse(
-            is.na(Residents.Deaths), 0, Residents.Deaths)) %>%
         mutate(Residents.Confirmed = Residents.Active + Residents.Deaths +
                    Residents.Recovered)
 }


### PR DESCRIPTION
Discovered through looking at the `group_by_coalesce` warnings: we want to make `Residents.Deaths` NAs 0 only in the first table, not in the staff table. Otherwise, we end up with conflicts we really don't want like: 
```
Group Date: 2021-01-01, Name: NORTHEAST CORRECTIONAL COMPLEX, State: Tennessee, jurisdiction_scraper: state, Facility.ID: 1258 has multiple values that do not match for column Residents.Deaths. Only using first of observed value from the following unique values 0, 5
```