### PR TITLE
fix: ca initiated fix

### DIFF
--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -163,7 +163,11 @@ california_vaccine_bi_extract <- function(x){
     x %>% 
         mutate_at(vars(-Name), string_to_clean_numeric) %>% 
         as_tibble() %>% 
-        clean_scraped_df()
+        clean_scraped_df() %>%
+        # inititaited needs to include completed to match our definition
+        mutate(Staff.Initiated = Staff.Initiated + Staff.Completed) %>%
+        mutate(Residents.Initiated = Residents.Initiated + Residents.Completed)
+        
 }
 
 #' Scraper class for general California vaccine COVID data from dashboard


### PR DESCRIPTION
Fix CA vaccine scraper so that initiated is equal to partially vaccinated  + Fully vaccinated. Need to re-extract old CA vaccine data to get this fixed for past runs as well. Will do once this pr is approved.