### PR TITLE
update: pa deaths prototype

### DIFF
--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -1,0 +1,150 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_cases_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9&",
+            "pageName=ReportSection331d709ad3ad8215c6c6")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_covid_cases <- raw_html %>%
+        rvest::html_node("div.preTextWithEllipsis") %>%
+        rvest::html_text() %>%
+        str_detect("(?=.*Inmate)(?=.*Positive)(?=.*Cases)") %>%
+        any()
+    
+    if(!is_covid_cases){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_cases_restruct  <- function(x){
+    
+    windows <- x %>%
+        rvest::html_nodes(xpath="//transform[@class='bringToFront']")
+    
+    df_list <- bind_rows(lapply(1:length(windows), function(i){
+        
+        wtitle <- windows[[i]] %>%
+            rvest::html_nodes(".preTextWithEllipsis") %>%
+            rvest::html_text() %>%
+            {ifelse(length(.) < 1, "", .)}
+        
+        if(str_detect(wtitle, "(?i)facility")){
+            if(str_detect(wtitle, "(?i)active")){
+                sub_df <- tibble(
+                    measure = "Residents.Active",
+                    
+                    Value = windows[[i]] %>%
+                        rvest::html_nodes(".label") %>%
+                        rvest::html_text(),
+                    
+                    Name = windows[[i]] %>%
+                        rvest::html_nodes("text.setFocusRing") %>%
+                        sapply(function(z){
+                            rvest::html_text(rvest::html_node(z, "title"))})
+                )
+            }
+            else if(str_detect(wtitle, "(?i)cumulative")){
+                sub_df <- tibble(
+                    measure = "Residents.Confirmed",
+                    
+                    Value = windows[[i]] %>%
+                        rvest::html_nodes(".label") %>%
+                        rvest::html_text(),
+                    
+                    Name = windows[[i]] %>%
+                        rvest::html_nodes("text.setFocusRing") %>%
+                        sapply(function(z){
+                            rvest::html_text(rvest::html_node(z, "title"))})
+                )
+            }
+        }
+        else{
+            sub_df <- tibble(Name = vector(mode = "character"))
+        }
+        sub_df
+        })) %>%
+        pivot_wider(names_from = measure, values_from = Value)
+    
+    
+}
+
+pennsylvania_bi_cases_extract <- function(x){
+    x %>%
+        clean_scraped_df() %>%
+        # i think we can assume not being present in the active table means zero
+        mutate(Residents.Active = ifelse(
+            is.na(Residents.Active), 0, Residents.Active))
+        
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_cases_scraper
+#' @description One page in PAs power BI tool which is dedicated to inmate
+#' deaths. We scrape each page with relevant data from the PA bi tool with
+#' separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Active}{COVID related death among inmates}
+#' }
+
+pennsylvania_bi_cases_scraper <- R6Class(
+    "pennsylvania_bi_cases_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            id = "pennsylvania_bi_cases",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_cases_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_cases_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_cases_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_cases <- pennsylvania_bi_cases_scraper$new(log=TRUE)
+    pennsylvania_bi_cases$raw_data
+    pennsylvania_bi_cases$pull_raw()
+    pennsylvania_bi_cases$raw_data
+    pennsylvania_bi_cases$save_raw()
+    pennsylvania_bi_cases$restruct_raw()
+    pennsylvania_bi_cases$restruct_data
+    pennsylvania_bi_cases$extract_from_raw()
+    pennsylvania_bi_cases$extract_data
+    pennsylvania_bi_cases$validate_extract()
+    pennsylvania_bi_cases$save_extract()
+}
+

--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -100,12 +100,13 @@ pennsylvania_bi_cases_extract <- function(x){
 #' 
 #' @name pennsylvania_bi_cases_scraper
 #' @description One page in PAs power BI tool which is dedicated to inmate
-#' deaths. We scrape each page with relevant data from the PA bi tool with
+#' cases. We scrape each page with relevant data from the PA bi tool with
 #' separate scrapers.
 #' 
 #' \describe{
 #'   \item{Facility}{Facility abbreviation}
-#'   \item{Active}{COVID related death among inmates}
+#'   \item{Active}{COVID active cases among inmates}
+#'   \item{Confirmed}{COVID confirmed cases among inmates}
 #' }
 
 pennsylvania_bi_cases_scraper <- R6Class(

--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -96,7 +96,7 @@ pennsylvania_bi_cases_extract <- function(x){
         
 }
 
-#' Scraper class for general PA death data from dashboard
+#' Scraper class for general PA case data from dashboard
 #' 
 #' @name pennsylvania_bi_cases_scraper
 #' @description One page in PAs power BI tool which is dedicated to inmate

--- a/production/scrapers/pennsylvania_bi_deaths.R
+++ b/production/scrapers/pennsylvania_bi_deaths.R
@@ -1,0 +1,111 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_deaths_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9",
+            "&pageName=ReportSectionc6adf1f0d7011b2ed62c")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_covid_deaths <- raw_html %>%
+        rvest::html_nodes(xpath="//div[@class='preTextWithEllipsis']") %>%
+        rvest::html_text() %>%
+        str_detect("(?=.*Inmate)(?=.*Death)(?=.*COVID)") %>%
+        any()
+    
+    if(!is_covid_deaths){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_deaths_restruct  <- function(x){
+    val_sr_str <- "//text[@class='label' and contains(@transform,'translate')]"
+    lab_sr_str <- "//text[@class='setFocusRing']//title"
+
+    tibble(
+        Name = raw_html %>%
+            rvest::html_nodes(xpath=lab_sr_str) %>%
+            rvest::html_text(),
+        
+        Residents.Deaths = raw_html %>%
+            rvest::html_nodes(xpath=val_sr_str) %>%
+            rvest::html_text())
+}
+
+
+
+
+pennsylvania_bi_deaths_extract <- function(x){
+    x %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_deaths_scraper
+#' @description One page in PAs power BI tool which is dedicated to inmate
+#' deaths. We scrape each page with relevant data from the PA bi tool with
+#' separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Deaths}{COVID related death among inmates}
+#' }
+
+pennsylvania_bi_deaths_scraper <- R6Class(
+    "pennsylvania_bi_deaths_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cdcr.ca.gov/covid19/updates/",
+            id = "pennsylvania_bi_deaths",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_deaths_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_deaths_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_deaths_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_deaths <- pennsylvania_bi_deaths_scraper$new(log=TRUE)
+    pennsylvania_bi_deaths$raw_data
+    pennsylvania_bi_deaths$pull_raw()
+    pennsylvania_bi_deaths$raw_data
+    pennsylvania_bi_deaths$save_raw()
+    pennsylvania_bi_deaths$restruct_raw()
+    pennsylvania_bi_deaths$restruct_data
+    pennsylvania_bi_deaths$extract_from_raw()
+    pennsylvania_bi_deaths$extract_data
+    pennsylvania_bi_deaths$validate_extract()
+    pennsylvania_bi_deaths$save_extract()
+}
+

--- a/production/scrapers/pennsylvania_bi_deaths.R
+++ b/production/scrapers/pennsylvania_bi_deaths.R
@@ -76,7 +76,7 @@ pennsylvania_bi_deaths_scraper <- R6Class(
         log = NULL,
         initialize = function(
             log,
-            url = "https://www.cdcr.ca.gov/covid19/updates/",
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
             id = "pennsylvania_bi_deaths",
             type = "html",
             state = "PA",

--- a/production/scrapers/pennsylvania_bi_deaths.R
+++ b/production/scrapers/pennsylvania_bi_deaths.R
@@ -40,11 +40,11 @@ pennsylvania_bi_deaths_restruct  <- function(x){
     lab_sr_str <- "//text[@class='setFocusRing']//title"
 
     tibble(
-        Name = raw_html %>%
+        Name = x %>%
             rvest::html_nodes(xpath=lab_sr_str) %>%
             rvest::html_text(),
         
-        Residents.Deaths = raw_html %>%
+        Residents.Deaths = x %>%
             rvest::html_nodes(xpath=val_sr_str) %>%
             rvest::html_text())
 }

--- a/production/scrapers/pennsylvania_bi_population.R
+++ b/production/scrapers/pennsylvania_bi_population.R
@@ -1,0 +1,111 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_population_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9",
+            "&pageName=ReportSection")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_population <- raw_html %>%
+        rvest::html_nodes(xpath="//div[@class='preTextWithEllipsis']") %>%
+        rvest::html_text() %>%
+        str_detect("(?=.*Inmate)(?=.*Population)") %>%
+        any()
+    
+    if(!is_population){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_population_restruct  <- function(x){
+    val_sr_str <- "//text[@class='label' and contains(@transform,'translate')]"
+    lab_sr_str <- "//text[@class='setFocusRing']//title"
+
+    tibble(
+        Name = x %>%
+            rvest::html_nodes(xpath=lab_sr_str) %>%
+            rvest::html_text(),
+        
+        Residents.Population = x %>%
+            rvest::html_nodes(xpath=val_sr_str) %>%
+            rvest::html_text())
+}
+
+
+
+
+pennsylvania_bi_population_extract <- function(x){
+    x %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_population_scraper
+#' @description One page in PAs power BI tool which is dedicated to inmate
+#' population. We scrape each page with relevant data from the PA bi tool with
+#' separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Population}{inmates population}
+#' }
+
+pennsylvania_bi_population_scraper <- R6Class(
+    "pennsylvania_bi_population_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cdcr.ca.gov/covid19/updates/",
+            id = "pennsylvania_bi_population",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_population_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_population_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_population_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_population <- pennsylvania_bi_population_scraper$new(log=TRUE)
+    pennsylvania_bi_population$raw_data
+    pennsylvania_bi_population$pull_raw()
+    pennsylvania_bi_population$raw_data
+    pennsylvania_bi_population$save_raw()
+    pennsylvania_bi_population$restruct_raw()
+    pennsylvania_bi_population$restruct_data
+    pennsylvania_bi_population$extract_from_raw()
+    pennsylvania_bi_population$extract_data
+    pennsylvania_bi_population$validate_extract()
+    pennsylvania_bi_population$save_extract()
+}
+

--- a/production/scrapers/pennsylvania_bi_population.R
+++ b/production/scrapers/pennsylvania_bi_population.R
@@ -57,7 +57,7 @@ pennsylvania_bi_population_extract <- function(x){
         clean_scraped_df()
 }
 
-#' Scraper class for general PA death data from dashboard
+#' Scraper class for general PA population data from dashboard
 #' 
 #' @name pennsylvania_bi_population_scraper
 #' @description One page in PAs power BI tool which is dedicated to inmate

--- a/production/scrapers/pennsylvania_bi_population.R
+++ b/production/scrapers/pennsylvania_bi_population.R
@@ -76,7 +76,7 @@ pennsylvania_bi_population_scraper <- R6Class(
         log = NULL,
         initialize = function(
             log,
-            url = "https://www.cdcr.ca.gov/covid19/updates/",
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
             id = "pennsylvania_bi_population",
             type = "html",
             state = "PA",

--- a/production/scrapers/pennsylvania_bi_staff_cases.R
+++ b/production/scrapers/pennsylvania_bi_staff_cases.R
@@ -94,7 +94,7 @@ pennsylvania_bi_staff_cases_extract <- function(x){
         
 }
 
-#' Scraper class for general PA death data from dashboard
+#' Scraper class for general PA death staff cases from dashboard
 #' 
 #' @name pennsylvania_bi_staff_cases_scraper
 #' @description One page in PAs power BI tool which is dedicated to staff

--- a/production/scrapers/pennsylvania_bi_staff_cases.R
+++ b/production/scrapers/pennsylvania_bi_staff_cases.R
@@ -1,0 +1,149 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_staff_cases_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9&",
+            "pageName=ReportSectiond9eef38c45a60b9e059a")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_covid_cases <- raw_html %>%
+        rvest::html_node("div.preTextWithEllipsis") %>%
+        rvest::html_text() %>%
+        str_detect("(?=.*Staff)(?=.*Cases)") %>%
+        any()
+    
+    if(!is_covid_cases){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_staff_cases_restruct  <- function(x){
+    
+    windows <- x %>%
+        rvest::html_nodes(xpath="//transform[@class='bringToFront']")
+    
+    df_list <- bind_rows(lapply(1:length(windows), function(i){
+        
+        wtitle <- windows[[i]] %>%
+            rvest::html_nodes(".preTextWithEllipsis") %>%
+            rvest::html_text() %>%
+            {ifelse(length(.) < 1, "", .)}
+        
+        if(str_detect(wtitle, "(?i)facility")){
+            if(str_detect(wtitle, "(?i)active")){
+                sub_df <- tibble(
+                    measure = "Drop.Staff.Active",
+                    
+                    Value = windows[[i]] %>%
+                        rvest::html_nodes(".label") %>%
+                        rvest::html_text(),
+                    
+                    Name = windows[[i]] %>%
+                        rvest::html_nodes("text.setFocusRing") %>%
+                        sapply(function(z){
+                            rvest::html_text(rvest::html_node(z, "title"))})
+                )
+            }
+            else if(str_detect(wtitle, "(?i)cumulative")){
+                sub_df <- tibble(
+                    measure = "Staff.Confirmed",
+                    
+                    Value = windows[[i]] %>%
+                        rvest::html_nodes(".label") %>%
+                        rvest::html_text(),
+                    
+                    Name = windows[[i]] %>%
+                        rvest::html_nodes("text.setFocusRing") %>%
+                        sapply(function(z){
+                            rvest::html_text(rvest::html_node(z, "title"))})
+                )
+            }
+        }
+        else{
+            sub_df <- tibble(Name = vector(mode = "character"))
+        }
+        sub_df
+        })) %>%
+        pivot_wider(names_from = measure, values_from = Value)
+    
+    
+}
+
+pennsylvania_bi_staff_cases_extract <- function(x){
+    x %>%
+        clean_scraped_df() %>%
+        select(-starts_with("Drop"))
+        
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_staff_cases_scraper
+#' @description One page in PAs power BI tool which is dedicated to staff
+#' cases. We scrape each page with relevant data from the PA bi tool with
+#' separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Active}{COVID active cases among staff}
+#'   \item{Confirmed}{COVID confirmed cases among staff}
+#' }
+
+pennsylvania_bi_staff_cases_scraper <- R6Class(
+    "pennsylvania_bi_staff_cases_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            id = "pennsylvania_bi_staff_cases",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_staff_cases_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_staff_cases_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_staff_cases_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_staff_cases <- pennsylvania_bi_staff_cases_scraper$new(log=TRUE)
+    pennsylvania_bi_staff_cases$raw_data
+    pennsylvania_bi_staff_cases$pull_raw()
+    pennsylvania_bi_staff_cases$raw_data
+    pennsylvania_bi_staff_cases$save_raw()
+    pennsylvania_bi_staff_cases$restruct_raw()
+    pennsylvania_bi_staff_cases$restruct_data
+    pennsylvania_bi_staff_cases$extract_from_raw()
+    pennsylvania_bi_staff_cases$extract_data
+    pennsylvania_bi_staff_cases$validate_extract()
+    pennsylvania_bi_staff_cases$save_extract()
+}
+

--- a/production/scrapers/pennsylvania_bi_testing.R
+++ b/production/scrapers/pennsylvania_bi_testing.R
@@ -1,0 +1,124 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_testing_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9&",
+            "pageName=ReportSection2804d81ebd8989abad15")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost", 
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_covid_testing <- raw_html %>%
+        rvest::html_nodes("div.preTextWithEllipsis") %>%
+        rvest::html_text() %>%
+        str_detect("(?=.*Inmate)(?=.*Tests)(?=.*Facility)") %>%
+        any()
+    
+    if(!is_covid_testing){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_testing_restruct  <- function(x){
+    
+    labs <- x %>%
+        rvest::html_nodes("text.setFocusRing") %>%
+        sapply(function(z){
+            rvest::html_text(rvest::html_node(z, "title"))})
+    
+    windows <- x %>%
+        rvest::html_nodes(".labelGraphicsContext")
+    
+    
+    possible_values <- lapply(windows, function(z){
+        z %>%
+            rvest::html_nodes(".label") %>%
+            rvest::html_text()
+    })
+    
+    idx <- which(lapply(possible_values, length) == length(labs))
+    
+    if(length(idx) != 1){
+        stop("Page is not as expected please inspect.")
+    }
+    
+    tibble(
+        Name = labs,
+        Residents.Tadmin = possible_values[[idx]]
+    )
+    
+}
+
+pennsylvania_bi_testing_extract <- function(x){
+    x %>%
+        clean_scraped_df()
+    
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_testing_scraper
+#' @description One page in PAs power BI tool which is dedicated to inmate
+#' testing. We scrape each page with relevant data from the PA bi tool with
+#' separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Tests}{Residents.Tadmin}
+#' }
+
+pennsylvania_bi_testing_scraper <- R6Class(
+    "pennsylvania_bi_testing_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            id = "pennsylvania_bi_testing",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_testing_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_testing_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_testing_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_testing <- pennsylvania_bi_testing_scraper$new(log=TRUE)
+    pennsylvania_bi_testing$raw_data
+    pennsylvania_bi_testing$pull_raw()
+    pennsylvania_bi_testing$raw_data
+    pennsylvania_bi_testing$save_raw()
+    pennsylvania_bi_testing$restruct_raw()
+    pennsylvania_bi_testing$restruct_data
+    pennsylvania_bi_testing$extract_from_raw()
+    pennsylvania_bi_testing$extract_data
+    pennsylvania_bi_testing$validate_extract()
+    pennsylvania_bi_testing$save_extract()
+}

--- a/production/scrapers/pennsylvania_bi_testing.R
+++ b/production/scrapers/pennsylvania_bi_testing.R
@@ -71,7 +71,7 @@ pennsylvania_bi_testing_extract <- function(x){
     
 }
 
-#' Scraper class for general PA death data from dashboard
+#' Scraper class for general PA testing data from dashboard
 #' 
 #' @name pennsylvania_bi_testing_scraper
 #' @description One page in PAs power BI tool which is dedicated to inmate

--- a/production/scrapers/pennsylvania_bi_vaccination.R
+++ b/production/scrapers/pennsylvania_bi_vaccination.R
@@ -1,0 +1,138 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+pennsylvania_bi_vaccination_pull <- function(x, wait = 10){
+    # scrape from the power bi iframe directly
+    y <- "https://app.powerbigov.us/view?r=" %>%
+        str_c(
+            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9",
+            "&pageName=ReportSection7b14ce996120a5295481")
+    
+    remDr <- RSelenium::remoteDriver(
+        remoteServerAddr = "localhost",
+        port = 4445,
+        browserName = "firefox"
+    )
+    
+    del_ <- capture.output(remDr$open())
+    remDr$navigate(y)
+    
+    Sys.sleep(wait)
+    
+    raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    is_vacc <- raw_html %>%
+        rvest::html_node(xpath="//div[@class='preTextWithEllipsis']") %>%
+        rvest::html_text() %>%
+        str_detect("(?i)vaccination") %>%
+        any()
+    
+    if(!is_vacc){
+        warning("Page structure may have changed please inspect.")
+    }
+    
+    raw_html
+}
+
+pennsylvania_bi_vaccination_restruct  <- function(x){
+    data_cards <- x %>%
+        rvest::html_nodes(xpath="//svg[@class='card']/../../..")
+    
+    titles <- x %>%
+        rvest::html_nodes(xpath="//div[@class='preTextWithEllipsis']") %>%
+        rvest::html_text()
+    
+    res_idx <- min(which(str_detect(titles, "(?i)inmate")))
+    staff_idx <- min(which(str_detect(titles, "(?i)staff")))
+    
+    if(res_idx > staff_idx){
+        stop("Scraper is not as expected, please inspect.")
+    }
+    
+    data_cards <- x %>%
+        rvest::html_nodes(xpath="//svg[@class='card']/../../..")
+    
+    card_labs <- sapply(data_cards, function(z){
+        rvest::html_attr(rvest::html_nodes(z, "div.visualTitle"), "title")
+        }) %>%
+        str_replace(" ", ".")
+    
+    card_group <- rep(c("Residents.", "Staff."), each = length(card_labs)/2)
+    
+    card_vals <- sapply(data_cards, function(z){
+        rvest::html_text(rvest::html_nodes(z, "title"))
+        }) %>%
+        string_to_clean_numeric()
+    
+    tibble(
+        name = str_c(card_group, card_labs),
+        value = card_vals
+    )
+}
+
+pennsylvania_bi_vaccination_extract <- function(x){
+    x %>%
+        pivot_wider() %>%
+        mutate(Residents.Initiated = Residents.Partial + Residents.Full) %>%
+        mutate(Staff.Initiated = Staff.Partial + Staff.Full) %>%
+        select(-ends_with("Not.Vaccinated"), -ends_with("Partial")) %>%
+        mutate(Name = "STATEWIDE") %>%
+        clean_scraped_df() %>%
+        rename(
+            Residents.Completed = Residents.Full, Staff.Completed = Staff.Full)
+}
+
+#' Scraper class for general PA death data from dashboard
+#' 
+#' @name pennsylvania_bi_vaccination_scraper
+#' @description One page in PAs power BI tool which is dedicated to inmate
+#' and staff vaccinations. We scrape each page with relevant data from the PA
+#' bi tool with separate scrapers.
+#' 
+#' \describe{
+#'   \item{Facility}{Facility abbreviation}
+#'   \item{Partial}{Completed - Initiated}
+#'   \item{Full}{Completed}
+#' }
+
+pennsylvania_bi_vaccination_scraper <- R6Class(
+    "pennsylvania_bi_vaccination_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            id = "pennsylvania_bi_vaccination",
+            type = "html",
+            state = "PA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = pennsylvania_bi_vaccination_pull,
+            # restructuring the data means pulling out the data portion of the 
+            restruct_func = pennsylvania_bi_vaccination_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = pennsylvania_bi_vaccination_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    pennsylvania_bi_vaccination <- pennsylvania_bi_vaccination_scraper$new(log=TRUE)
+    pennsylvania_bi_vaccination$raw_data
+    pennsylvania_bi_vaccination$pull_raw()
+    pennsylvania_bi_vaccination$raw_data
+    pennsylvania_bi_vaccination$save_raw()
+    pennsylvania_bi_vaccination$restruct_raw()
+    pennsylvania_bi_vaccination$restruct_data
+    pennsylvania_bi_vaccination$extract_from_raw()
+    pennsylvania_bi_vaccination$extract_data
+    pennsylvania_bi_vaccination$validate_extract()
+    pennsylvania_bi_vaccination$save_extract()
+}
+

--- a/production/scrapers/pennsylvania_bi_vaccination.R
+++ b/production/scrapers/pennsylvania_bi_vaccination.R
@@ -83,7 +83,7 @@ pennsylvania_bi_vaccination_extract <- function(x){
             Residents.Completed = Residents.Full, Staff.Completed = Staff.Full)
 }
 
-#' Scraper class for general PA death data from dashboard
+#' Scraper class for general PA vaccination data from dashboard
 #' 
 #' @name pennsylvania_bi_vaccination_scraper
 #' @description One page in PAs power BI tool which is dedicated to inmate

--- a/production/scrapers/pennsylvania_population.R
+++ b/production/scrapers/pennsylvania_population.R
@@ -6,6 +6,7 @@ pennsylvania_population_pull <- function(x){
 }
 
 pennsylvania_population_restruct <- function(x){
+    stop_defunct_scraper("https://www.cor.pa.gov/Pages/COVID-19.aspx")
     x %>%
         rvest::html_node("table") %>%
         rvest::html_table(header = TRUE) %>%


### PR DESCRIPTION
Went through the PA bi dashboard this morning. It looks like it is not so bad to pull data directly from the chart which cuts down on code complexity a lot. Somehow its more work to navigate to their tables and extract from there??? In addition, I think it makes sense to have a separate scraper for each page of the bi tool we want to pull data from for similar code complexity reasons. While this means we are going to need like 6 new scrapers. They should be fairly simple. The deaths example in this PR was less than 50 lines of new code. Keeping as a draft to see if we agree on this approach.