### PR TITLE
chore: various diagnostic checks 

### DIFF
--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -366,6 +366,10 @@ generic_scraper <- R6Class(
             less_check("Residents.Tested", "Residents.Confirmed")
             less_check("Staff.Tested", "Staff.Negative")
             less_check("Residents.Tested", "Residents.Negative")
+            less_check("Residents.Initiated", "Residents.Completed")
+            less_check("Staff.Initiated", "Staff.Completed")
+            less_check("Residents.Vadmin", "Residents.Initiated")
+            less_check("Staff.Vadmin", "Staff.Initiated")
         },
         
         validate_extract = function(){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -550,7 +550,7 @@ write_agg_data <- function(...){
     write_csv("./data/latest-data/national_aggregate_counts.csv", na="")
 }
 
-write_latest_data <- function(coalesce = TRUE, fill = FALSE, fac_window = 60, agg_window = 60){
+write_latest_data <- function(coalesce = TRUE, fill = FALSE, fac_window = 31, agg_window = 31){
   
     out_df <- read_scrape_data(all_dates = FALSE, coalesce = TRUE, window = fac_window)
     

--- a/production/redo_scrape/README_redo.md
+++ b/production/redo_scrape/README_redo.md
@@ -4,7 +4,7 @@ There are instances where we have raw data files on our database sserver for whi
 
 ## 1. Re-do the scrape
 ```
-production/redo_scrape/main_redo.R --scraper nyc_jails --start 2020-11-01 --end 2020-12-31
+Rscript production/redo_scrape/main_redo.R --scraper nyc_jails --start 2020-11-01 --end 2020-12-31
 ```
 
 This specification tells the redo scraper pipeline to run the `nyc_jails` scraper for any dates which we have raw files on the server in Nov and Dec 2020. To see more details on how to run this file see:

--- a/reports/post_diagnostics.Rmd
+++ b/reports/post_diagnostics.Rmd
@@ -8,11 +8,8 @@ output:
 ---
 
 ```{r setup, include = F}
-library(devtools)
 library(tidyverse)
-library(googlesheets4)
 library(kableExtra)
-devtools::install_github("uclalawcovid19behindbars/behindbarstools")
 library(behindbarstools)
 ```
 
@@ -26,7 +23,7 @@ The table below summarizes the scrapers that yielded errors and warnings. Highli
 
 ``` {r echo = F, warning = F}
 # Read latest facility data 
-new_df <- read_scrape_data(all_dates = FALSE, coalesce = TRUE, window = 60)
+new_df <- read_scrape_data(all_dates = FALSE, coalesce = TRUE, window = 31)
 
 # Get all log files from the latest run 
 latest_date <- max(new_df$Date) %>% 
@@ -148,7 +145,7 @@ This compares to the state-aggregated totals in `state_aggregate_counts.csv` whi
 
 ```{r check_previous_state, echo = F, message = F, warning = F}
 # Read latest statewide data 
-new_state_df <- behindbarstools::calc_aggregate_counts(state = TRUE, window = 60)
+new_state_df <- behindbarstools::calc_aggregate_counts(state = TRUE, window = 31)
 
 # Read old data 
 old_state_df <- stringr::str_c(
@@ -183,14 +180,14 @@ kable(measure_decline_df, format.args = list(big.mark = ",")) %>%
 
 **How does our aggregated data compare to data from AP and the Marshall Project?** 
 
-AP and the Marshall Project report [data on COVID in prisons at the state-level](https://www.themarshallproject.org/2020/05/01/a-state-by-state-look-at-coronavirus-in-prisons) each week. Because of differences in our methodology (e.g. data sources, update frequency, etc.), we do NOT expect our statewide totals to perfectly align with data from AP/TMP. The table below highlights states where our totals differ by more than 20%. 
+AP and the Marshall Project report [data on COVID in prisons at the state-level](https://www.themarshallproject.org/2020/05/01/a-state-by-state-look-at-coronavirus-in-prisons) each week. Because of differences in our methodology (e.g. data sources, update frequency, etc.), we do NOT expect our statewide totals to perfectly align with data from AP/TMP. The table below includes states where our totals differ by more than 20% OR where TMP is reporting values higher than we are. 
 
 ``` {r, echo = F}
 # Read Marshall Project data 
 new_state_df %>% 
     filter(!is.na(UCLA) & !is.na(MP)) %>% 
-    mutate(pct_diff = scales::percent(abs((MP - UCLA) / UCLA))) %>% 
-    filter(pct_diff > 20) %>%
+    mutate(pct_diff = abs((MP - UCLA) / UCLA)) %>% 
+    filter(pct_diff > 0.2 | MP > UCLA) %>%
     arrange(desc(pct_diff)) %>% 
     select(State, Measure, UCLA, MP) %>%
     kable(format.args = list(big.mark = ",")) %>% 


### PR DESCRIPTION
Various small things in here to hopefully make data QC a little more streamlined: 
* Adding checks for vaccine data (shouldn't be more people completed than initiated, should be more people initiated than doses administered) that should hopefully throw warnings if more states start moving people from `Initaited` to `Completed` rather than using our definitions
* Pushing the coalesce and aggregate windows back to 31 days  
* Fixing a dumb bug I wrote in the diagnostics script that made the comparisons to TMP data hard to interpret 
* Flagging metrics where TMP is reporting numbers higher than us since this should theoretically not happen 