### PR TITLE
fix: update vaccine sum NA behavior

### DIFF
--- a/production/scrapers/federal.R
+++ b/production/scrapers/federal.R
@@ -67,8 +67,8 @@ federal_restruct <- function(x){
             comb_df,
             tibble(
                 Name = "ALL BOP FACILITIES",
-                Residents.Completed = sum(x$vaccine$bopVaccine$inmateCompleted),
-                Staff.Completed = sum(x$vaccine$bopVaccine$staffCompleted)
+                Residents.Completed = sum_na_rm(x$vaccine$bopVaccine$inmateCompleted),
+                Staff.Completed = sum_na_rm(x$vaccine$bopVaccine$staffCompleted)
             ))
     }
     

--- a/production/scrapers/idaho_vaccine.R
+++ b/production/scrapers/idaho_vaccine.R
@@ -36,6 +36,7 @@ idaho_vaccine_extract <- function(x){
                 Residents.FirstDose = CRC.Residents.FirstDose_, 
                 Residents.Full = CRC.Residents.Full_)
         ) %>% 
+        mutate(across(where(is.numeric), ~ ifelse(is.na(.), 0, .))) %>% 
         mutate(Residents.Initiated = Residents.FirstDose + Residents.Full,
                Residents.Completed = Residents.Full) %>%
         select(Name, Residents.Initiated, Residents.Completed) %>%

--- a/production/scrapers/minnesota_vaccine.R
+++ b/production/scrapers/minnesota_vaccine.R
@@ -32,6 +32,7 @@ minnesota_vaccine_extract <- function(x, exp_date = Sys.Date()){
     x %>%
         {suppressWarnings(mutate_at(., vars(starts_with("Staff")), as.numeric))} %>%
         {suppressWarnings(mutate_at(., vars(starts_with("Client")), as.numeric))} %>%
+        mutate(across(where(is.numeric), ~ ifelse(is.na(.), 0, .))) %>%
         mutate(
             Residents.Initiated = `Client Received 1st Dose` + `Client Received J&J Vaccine`, 
             Residents.Completed = `Client Received 2nd Dose` + `Client Received J&J Vaccine`, 


### PR DESCRIPTION
We'll need to re-scrape Idaho and probably Minnesota going back pretty far – although that will be annoying because we'll have to either (1) use a version of the scraper before they changed columns last Wed or (2) create a big `if else` conditional in the scraper code for before/after last Wed. 