### PR TITLE
fix: resolve statewide conflicts

### DIFF
--- a/production/scrapers/florida_url.R
+++ b/production/scrapers/florida_url.R
@@ -56,9 +56,7 @@ process_FL_image <- function(base_image, ...){
         # Positive inmates cleared: cleared 
         Residents.Recovered = process_FL_cell(base_image, "300x42+700+305", ...),
         # Positive staff cleared: cleared 
-        Staff.Recovered = process_FL_cell(base_image, "300x42+700+430", ...),
-        # COVID-19 related inmate deaths 
-        Residents.Deaths = process_FL_cell(base_image, "400x105+0+545", ...)
+        Staff.Recovered = process_FL_cell(base_image, "300x42+700+430", ...)
     )
 }
 

--- a/production/scrapers/oregon.R
+++ b/production/scrapers/oregon.R
@@ -38,9 +38,8 @@ oregon_extract <- function(x){
                Residents.Active = "Current AIC Active Cases",
                Residents.Deaths = "AIC Deaths") %>%
         clean_scraped_df() %>%
-        mutate(
-               Residents.Tadmin = Residents.Confirmed + Residents.Negative
-               ) %>%
+        mutate(Residents.Tadmin = 
+                   ifelse(Name == "State-Wide", NA, Residents.Confirmed + Residents.Negative)) %>% 
         mutate(Staff.Confirmed =
                    ifelse(Name == "State-Wide", NA, Staff.Confirmed)) %>%
         # doing this because Residents.Confirmed = positive tests, not positive cases (?)

--- a/production/scrapers/vermont.R
+++ b/production/scrapers/vermont.R
@@ -21,6 +21,8 @@ vermont_extract <- function(x, exp_date = Sys.Date()){
         filter(!is.na(Name)) %>% 
         select(Name, Staff.Confirmed, Residents.Confirmed, Staff.Deaths, Residents.Deaths, 
                Residents.Recovered, Residents.Tested) %>% 
+        mutate(Residents.Confirmed =
+                   ifelse(str_detect(Name, "(?i)state-wide|statewide"), NA, Residents.Confirmed)) %>%
         clean_scraped_df()
 }
 

--- a/production/scrapers/wyoming.R
+++ b/production/scrapers/wyoming.R
@@ -29,7 +29,12 @@ wyoming_extract <- function(x, exp_date = Sys.Date()){
             Name = `Name`,
             Residents.Active = `Positive Inmate Cases`,
             Residents.Deaths = `Inmate Deaths`) %>% 
-        clean_scraped_df()
+        # Only reporting statewide deaths
+        # This should just replace 0's with NAs as a fail safe 
+        mutate(Residents.Deaths = ifelse(
+            Name != "STATEWIDE", NA, Residents.Deaths)) %>%  
+        clean_scraped_df() 
+        
 }
 
 #' Scraper class for Wyoming data 


### PR DESCRIPTION
See https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/210: little code changes, big bugs. Should re-scrape Wyoming, Oregon, and Florida. 

The Wisconsin issue is crosswalk related – fixing that separately in that repo. 