### PR TITLE
fix: georgia and maine 

### DIFF
--- a/production/historical_scrape/historical_scrapers/historical_georgia.R
+++ b/production/historical_scrape/historical_scrapers/historical_georgia.R
@@ -1,0 +1,92 @@
+source("./R/generic_scraper.R")
+
+georgia_pull <- function(x, file, date = NULL){
+    # Get API endpoint from permacc 
+    # Example of file url from 2021-01-27: "lju7-43hn/20210127215032mp_"
+    stringr::str_c(
+        "https://wr.perma-archives.org/public/", 
+        file, 
+        "/https://services5.arcgis.com/mBtYHKRd2hqJxboF/arcgis/rest/services/", 
+        "COVID19StatewideV2/FeatureServer/0/query?f=json&where=1%3D1&", 
+        "returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&",
+        "resultOffset=0&resultRecordCount=1000&resultType=standard&cacheHint=true") %>%
+        jsonlite::read_json(simplifyVector = TRUE)
+}
+
+#' Scraper class for historical Georgia COVID data
+#' Uses permacc saves to reconstruct the API endpoint 
+#' 
+#' @name georgia_scraper
+#' @description Georgia data comes from an api which needs minimal cleaning.
+#' \describe{
+#'   \item{Facility_Name}{The faciilty name.}
+#'   \item{Latitude}{Lat.}
+#'   \item{Longitude}{Long.}
+#'   \item{Address}{Address of the facility.}
+#'   \item{City}{City location of facility.}
+#'   \item{State}{State location of facility (should always be Georgia).}
+#'   \item{Zip}{Zip code of facility.}
+#'   \item{Staff Confirmed}{Cumulative staff confirmed.}
+#'   \item{Staff Deaths}{Cumulative staff deaths.}
+#'   \item{Staff Recovered}{Cumulative staff recovered.}
+#'   \item{Inmate Confirmed}{Cumulative resident confirmed.}
+#'   \item{Inmate Deaths}{Cumulative resident deaths.}
+#'   \item{Inmate Recovered}{Cumulative resident recovered.}
+#'   \item{Private Prison}{Y/N is this a private prison.}
+#'   \item{Confirmed Display}{Display format for vizualizations.}
+#'   \item{Death Dispaly}{Display format for vizualizations.}
+#'   \item{Recovered Display}{Display format for vizualizations.}
+#'   \item{FID}{Georgia internal facility id.}
+#' }
+
+historical_georgia_scraper <- R6Class(
+    "historical_georgia_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "http://www.dcor.state.ga.us/content/CVD_Dashboard",
+            # Uses same ID as main Georgia scraper! 
+            id = "georgia",
+            type = "json",
+            state = "GA",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = georgia_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = function(x, date = NULL) as_tibble(x$features$attributes),
+            # Rename the columns to appropriate database names
+            extract_func = function(x, date = NULL){
+                x %>% 
+                    select(
+                        Name = Facility_Name, 
+                        Staff.Confirmed = Staff_Confirmed, 
+                        Staff.Recovered = Staff_Recovered, 
+                        Staff.Deaths = Staff_Deaths, 
+                        Residents.Confirmed = Inmate_Confirmed, 
+                        Residents.Recovered = Inmate_Recovered, 
+                        Residents.Deaths = Inmate_Deaths, 
+                        )}){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    historical_georgia <- historical_georgia_scraper$new(log=TRUE)
+    historical_georgia$reset_date("DATE")
+    historical_georgia$raw_data
+    historical_georgia$pull_raw(file, .dated_pull = TRUE)
+    historical_georgia$raw_data
+    historical_georgia$save_raw()
+    historical_georgia$restruct_raw()
+    historical_georgia$restruct_data
+    historical_georgia$extract_from_raw()
+    historical_georgia$extract_data
+    historical_georgia$validate_extract()
+    historical_georgia$save_extract()
+}

--- a/production/scrapers/georgia.R
+++ b/production/scrapers/georgia.R
@@ -2,11 +2,10 @@ source("./R/generic_scraper.R")
 
 georgia_pull <- function(x){
     stringr::str_c(
-        "https://services5.arcgis.com/mBtYHKRd2hqJxboF/arcgis/rest/services/",
-        "COVID19Statewide/FeatureServer/0/query?f=json&where=1%3D1&",
+        "https://services5.arcgis.com/mBtYHKRd2hqJxboF/arcgis/rest/services/", 
+        "COVID19StatewideVaccineV42/FeatureServer/0/query?f=json&where=1%3D1&", 
         "returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&",
-        "resultOffset=0&resultRecordCount=1000&resultType=standard",
-        "&cacheHint=true") %>%
+        "resultOffset=0&resultRecordCount=1000&resultType=standard&cacheHint=true") %>%
         jsonlite::read_json(simplifyVector = TRUE)
 }
 
@@ -33,6 +32,12 @@ georgia_pull <- function(x){
 #'   \item{Death Dispaly}{Display format for vizualizations.}
 #'   \item{Recovered Display}{Display format for vizualizations.}
 #'   \item{FID}{Georgia internal facility id.}
+#'   \item{Staff_Vaccine_1}{}
+#'   \item{Staff_Vaccine_2}{}
+#'   \item{Inmate_Vaccine_1}{}
+#'   \item{Inmate_Vaccine_2}{}
+#'   \item{Total_Vaccinated}{}
+#'   \item{VaccinatedDisplay}{}
 #' }
 
 georgia_scraper <- R6Class(
@@ -55,11 +60,16 @@ georgia_scraper <- R6Class(
             extract_func = function(x){
                 x %>% 
                     select(
-                        Name = Facility_Name, Staff.Confirmed = Staff_Confirmed, 
-                        Staff.Recovered = Staff_Recovered, Staff.Deaths = Staff_Deaths, 
+                        Name = Facility_Name, 
+                        Staff.Confirmed = Staff_Confirmed, 
+                        Staff.Recovered = Staff_Recovered, 
+                        Staff.Deaths = Staff_Deaths, 
                         Residents.Confirmed = Inmate_Confirmed, 
                         Residents.Recovered = Inmate_Recovered, 
-                        Residents.Deaths = Inmate_Deaths)}){
+                        Residents.Deaths = Inmate_Deaths, 
+                        Staff.Initiated = Staff_Vaccine_1, 
+                        Residents.Initiated = Inmate_Vaccine_1
+                        )}){
             super$initialize(
                 url = url, id = id, pull_func = pull_func, type = type,
                 restruct_func = restruct_func, extract_func = extract_func,
@@ -80,4 +90,3 @@ if(sys.nframe() == 0){
     georgia$validate_extract()
     georgia$save_extract()
 }
-


### PR DESCRIPTION
Bad news: Georgia changed the API powering their dashboard but didn't take down the old one, so the scraper never picked this up. As a result, the numbers we've been reporting since December (below) are wrong. 

<img src="https://user-images.githubusercontent.com/47676353/116003492-cd823380-a5c3-11eb-8fad-d9a9af224485.png" height="300">

Good news: We can use our perma.cc saves to get the API endpoints and update the old data! The wayback URLs didn't work for some reason, so I set it up as a historical scraper instead. Here's a snapshot of what the config file would look like: 

<img width="384" alt="Screen Shot 2021-04-25 at 12 45 34 PM" src="https://user-images.githubusercontent.com/47676353/116003575-26ea6280-a5c4-11eb-9f9b-e4ea686abd4f.png">

In addition to updating the Georgia API URL, this PR also adds vaccine data to both Georgia and Maine. 