### PR TITLE
chore: make vanguard scrapers more robust

### DIFF
--- a/production/scrapers/santa_clara_county_jail.R
+++ b/production/scrapers/santa_clara_county_jail.R
@@ -8,8 +8,11 @@ santa_clara_county_jail_pull <- function(x){
 
 santa_clara_county_jail_restruct <- function(x){
     x %>%
+        janitor::clean_names(case = "title") %>%
         mutate(Date = lubridate::round_date(`As of Date`, unit = "day")) %>%
         mutate(Date = as.Date(Date)) %>%
+        # Pull most recent date with non-NA Residents.Confirmed 
+        filter(!is.na(`Confirmed Cases Incarcerated Population Cumulative`)) %>% 
         filter(Date == max(Date))
 }
 
@@ -19,17 +22,22 @@ santa_clara_county_jail_extract <- function(x, exp_date = Sys.Date()){
     
     x %>% 
         select(
-            Residents.Active = `Active Cases (Incarcerated population, current)`, 
-            Residents.Confirmed = `Confirmed Cases (Incarcerated population, cumulative)`,
-            Residents.Tadmin = `Tests (Incarcerated population, cumulative)`,
-            Residents.Population = `Population (Incarcerated population, current)`,
-            Residents.Initiated = `Partially Vaccinated (Incarcerated population, cumulative)`, 
-            Residents.Completed = `Fully Vaccinated (Incarcerated population, cumulative)`,
-            Staff.Completed = `Fully Vaccinated (Custody staff, cumulative)`, 
-            Staff.Population = `Population (Custody Staff, current)`
-        ) %>%
-            mutate(Name = "SANTA CLARA COUNTY JAIL") %>% 
-            mutate(Residents.Initiated = Residents.Initiated + Residents.Completed)
+            Residents.Active = `Active Cases Incarcerated Population Current`, 
+            Residents.Confirmed = `Confirmed Cases Incarcerated Population Cumulative`,
+            Residents.Tadmin = `Tests Incarcerated Population Cumulative`,
+            Residents.Population = `Population Incarcerated Population Current`,
+            Residents.Partial.Drop = `Partially Vaccinated Incarcerated Population Cumulative`, 
+            Residents.Completed = `Fully Vaccinated Incarcerated Population Cumulative`,
+            Staff.Completed = `Fully Vaccinated Custody Staff Cumulative`, 
+            Staff.Population = `Population Custody Staff Current`
+        ) %>% 
+        rowwise() %>% 
+        mutate(Residents.Initiated = sum(Residents.Partial.Drop, Residents.Completed, na.rm = T)) %>% 
+        mutate(Residents.Initiated = ifelse(
+            is.na(Residents.Partial.Drop) & is.na(Residents.Completed), NA, Residents.Initiated)) %>% 
+        mutate_all(as.numeric) %>%
+        select(-ends_with("Drop")) %>% 
+        mutate(Name = "SANTA CLARA COUNTY JAIL") 
 }
 
 #' Scraper class for general santa_clara_county_jail COVID data


### PR DESCRIPTION
Adds the following to all of the Vanguard scrapers: 
* Pulls most recent date with non-NA cumulative cases 
* Cleans all names at the top to avoid warnings/errors from changes in parentheses, capitalization, etc. 
* Sums vaccine variables correctly (`NA + NA = NA`, `NA + # = #`) 

And thoughts on calling the Yolo County scraper defunct? The Google Sheet hasn't been updated since January.  