### PR TITLE
update: add facility-level federal vaccine data 

### DIFF
--- a/production/scrapers/federal.R
+++ b/production/scrapers/federal.R
@@ -117,6 +117,9 @@ federal_extract <- function(x){
 #'   \item{inmateCompletedTest}{Tests adminstered, I think not individuals tested}
 #'   \item{inmatePendTest}{Current Pending Cases}
 #'   \item{inmatePosTest}{Cumulative Positive Cases}
+#'   \item{inmateCompleted}{Residents.Completed}
+#'   \item{staffCompleted}{Staff.Completed}
+#'   
 #' }
 
 federal_scraper <- R6Class(


### PR DESCRIPTION
At long last, I think we're ready to have our federal COVID data, population data, and vaccine data all be reported in a logical way! Corresponding crosswalk and info overhaul in [this PR](https://github.com/uclalawcovid19behindbars/facility_data/pull/51). 