### PR TITLE
update: fix NH and WV scrapers

### DIFF
--- a/production/scrapers/new_hampshire.R
+++ b/production/scrapers/new_hampshire.R
@@ -60,7 +60,7 @@ new_hampshire_extract <- function(x){
     
     rez_exp <- c(
         Name = "Facility",
-        Residents.Tested = "Residents COVID-19 Tests Administered",
+        Residents.Tadmin = "Residents COVID-19 Tests Administered",
         Residents.Active = "Active Residents Positive",
         Residents.Confirmed =
             "Total Residents who have tested positive since March 2020",
@@ -107,7 +107,7 @@ new_hampshire_extract <- function(x){
 #' \describe{
 #'   \item{Name}{The facility name.}
 #'   \item{Num Staff Positive}{The staff number testing positive}
-#'   \item{Num Residents tested}{Not the number of tests administered}
+#'   \item{Num Residents tested}{Number of tests administered}
 #'   \item{Num Residents Positive}{Number of residents confirmed}
 #'   \item{NHDOC Staff}{State wide staff population}
 #'   \item{Total resident population}{State wide incarcerated population}

--- a/production/scrapers/west_virginia_vaccine.R
+++ b/production/scrapers/west_virginia_vaccine.R
@@ -46,19 +46,21 @@ west_virginia_vaccine_extract <- function(x){
         clean_scraped_df()
     
     staff_df <- x[emp_idx:nrow(x),] %>%
-        filter(str_detect(Name, "(?i)total")) %>%
+        filter(!str_detect(Name, "(?i)total")) %>%
         select(-`Moderna \n(1st dose)`)
     
     names(staff_df) <- as.character(na.omit(unlist(x[emp_idx,])))
     
     staff_df %>%
         select(
+            Name = `EMPLOYEES (Moderna)`, 
             Staff.Initiated = `1st Doses`,
             Staff.Completed = `2nd Doses`,
             Staff.Population = `Staffing*`
             ) %>%
-        mutate(Name = "State-Wide") %>%
+        filter(Name != "EMPLOYEES (Moderna)") %>% 
         clean_scraped_df() %>%
+        mutate(Name = stringr::str_c(Name, " staff total")) %>% 
         # moderna so this should work
         mutate(Staff.Vadmin = Staff.Initiated + Staff.Completed) %>%
         bind_rows(res_df)


### PR DESCRIPTION
1. Disaggregating West Virginia staff so that we can split up state, county, and youth later on in the pipeline. 
2. Making New Hampshire's testing variable `Residents.Tadmin` rather than `Residents.Tested` upon confirming from the DOC that the variable refers to tests administered. 

Both will require re-scrapes! 