### PR TITLE
update: update state_agg write

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -538,7 +538,7 @@ write_agg_data <- function(...){
   sel_vars <- c(
     "Residents.Confirmed", "Staff.Confirmed",
     "Residents.Deaths", "Staff.Deaths",
-    "Residents.Recovered", "Staff.Recovered", "Residents.Tadmin",
+    "Residents.Tadmin",
     "Residents.Initiated", "Staff.Initiated"
   )
   
@@ -550,23 +550,36 @@ write_agg_data <- function(...){
     write_csv("./data/latest-data/national_aggregate_counts.csv", na="")
 }
 
+write_state_agg_data <- function(...){
+    full_var_df <- calc_aggregate_counts(...)
+    aggregate_pop_df <- read_aggregate_pop_data()
+    
+    full_var_df %>%
+        # Pivot wide 
+        filter(!is.na(Val)) %>%
+        select(State, Measure, Val) %>%
+        pivot_wider(names_from = "Measure", values_from = "Val") %>%
+        arrange(State) %>%
+        select(State, ends_with(covid_suffixes)) %>% 
+        select(-Staff.Tested) %>% 
+        # Join with population anchors 
+        left_join(aggregate_pop_df, by = "State") %>% 
+        write_csv("./data/latest-data/state_aggregate_counts.csv", na="")
+}
+
 write_latest_data <- function(coalesce = TRUE, fill = FALSE, fac_window = 31, agg_window = 31){
   
     out_df <- read_scrape_data(all_dates = FALSE, window = fac_window)
     
     covid_suffixes <- c(
-      ".Confirmed", ".Deaths", ".Recovered", ".Tadmin", ".Tested", ".Active",
-      ".Negative", ".Pending", ".Quarantine", ".Initiated", ".Completed", ".Vadmin")
+      ".Confirmed", ".Deaths", ".Tadmin", ".Tested", ".Active",
+      ".Initiated", ".Completed", ".Vadmin")
     
     rowAny <- function(x) rowSums(x) > 0
     
     out_df %>%
         # Drop rows missing COVID data (e.g. only with population data)
         filter(rowAny(across(ends_with(covid_suffixes), ~ !is.na(.x)))) %>%
-        # drop rows related to statewide counts after notifying CDC and hobject
-        # filter(Name != "STATEWIDE") %>%
-        # filter(Name != "ALL BOP FACILITIES") %>%
-        # filter(Name != "ALL ICE FACILITIES") %>%
         select(all_of(ends_with(covid_suffixes))) %>%
         summarize_all(sum_na_rm) %>%
         pivot_longer(
@@ -575,37 +588,29 @@ write_latest_data <- function(coalesce = TRUE, fill = FALSE, fac_window = 31, ag
             values_to = "Count") %>%
         print()
     
+    # Write facility-level data 
     out_df %>%
         # Drop rows missing COVID data (e.g. only with population data)
         filter(rowAny(across(ends_with(covid_suffixes), ~ !is.na(.x)))) %>%
-        # drop rows related to statewide counts after notifying CDC and hobject
-        # filter(Name != "STATEWIDE") %>%
-        # filter(Name != "ALL BOP FACILITIES") %>%
-        # filter(Name != "ALL ICE FACILITIES") %>%
         select(
             Facility.ID, Jurisdiction, State, Name, Date, source,
             Residents.Confirmed, Staff.Confirmed,
-            Residents.Deaths, Staff.Deaths, Residents.Recovered,
-            Staff.Recovered, Residents.Tadmin, Staff.Tested, Residents.Negative,
-            Staff.Negative, Residents.Pending, Staff.Pending,
-            Residents.Quarantine, Staff.Quarantine, Residents.Active, Staff.Active,
-            Population.Feb20, Residents.Population, Residents.Tested, 
-            Residents.Initiated, Staff.Initiated, Residents.Completed, Staff.Completed, 
-            Residents.Vadmin, Staff.Vadmin, Address, Zipcode, City, County, Latitude,
+            Residents.Deaths, Staff.Deaths, 
+            Residents.Tadmin, Residents.Tested, 
+            Residents.Active, Staff.Active,
+            Population.Feb20, Residents.Population, 
+            Residents.Initiated, Staff.Initiated, 
+            Residents.Completed, Staff.Completed, 
+            Residents.Vadmin, Staff.Vadmin, 
+            Address, Zipcode, City, County, Latitude,
             Longitude, County.FIPS, HIFLD.ID, ICE.Field.Office) %>% 
         write_csv("./data/latest-data/adult_facility_covid_counts.csv", 
                   na="")
 
-    full_var_df <- behindbarstools::calc_aggregate_counts(
-        state = TRUE, window = agg_window)
-
-    full_var_df %>%
-        filter(!is.na(Val)) %>%
-        select(State, Measure, Val) %>%
-        pivot_wider(names_from = "Measure", values_from = "Val") %>%
-        arrange(State) %>%
-        write_csv("./data/latest-data/state_aggregate_counts.csv", na="")
+    # Write state-level data 
+    write_state_agg_data(state = TRUE, window = agg_window)
     
+    # Write national-level data 
     write_agg_data(window = agg_window)
 }
 


### PR DESCRIPTION
Updates `write_latest_data` based on what we discussed today: 
* Trims down our list of variables by removing `.Pending`, `.Quarentine`, `.Negative`, `.Recovered`
* Adds 3 new columns for the various population anchors to the state-aggregated file (`Residents.Population.Feb20`, `Residents.Population.Jan21` and `Staff.Population`) – because this data is wide, I think this is the only way to get those included 

Before merging, this requires: 
- [ ] [This PR](https://github.com/uclalawcovid19behindbars/behindbarstools/pull/104) in `barstools` to be merged 
- [ ] The Google Sheet to be updated (both the aggregate tab and the facility-level tab) given new columns 
- [ ] Updating the data repo documentation 
- [ ] Maaaaybe consulting with Hyperobjekt/CDC to avoid things breaking for them 