### PR TITLE
fix: update alabama vaccine variables

### DIFF
--- a/production/scrapers/alabama.R
+++ b/production/scrapers/alabama.R
@@ -33,8 +33,8 @@ alabama_extract <- function(x){
             Staff.Deaths = Employee_Death,
             Staff.Recovered = Employee_Recovered, 
             Staff.Active = Employee_Active_Cases, 
-            Staff.Vadmin = Employee_Vaccinations, 
-            Residents.Vadmin = Inmate_Vaccinations
+            Staff.Initiated = Employee_Vaccinations, 
+            Residents.Initiated = Inmate_Vaccinations
         )
 }
 


### PR DESCRIPTION
Got an email back from the Alabama DOC saying their vaccine variables are initiated. 

Just updated the [wiki](https://github.com/uclalawcovid19behindbars/data/wiki/Alabama) and will run this! 
```
Rscript production/redo_scrape/main_redo.R —scraper alabama —start 2021-03-36 —end 2021-05-19
```