### PR TITLE
update: wv vaccine fix 

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -5,7 +5,7 @@ library(behindbarstools)
 library(futile.logger)
 source("R/generic_scraper.R")
 
-basic_check <- function(true_names, expected_names){
+basic_check <- function(true_names, expected_names, detect = FALSE){
     if(length(true_names) != length(expected_names)){
         warning("Length of expected names does not match actual names")
     }
@@ -19,19 +19,32 @@ basic_check <- function(true_names, expected_names){
             else{
                 cexp <- clean_fac_col_txt(expected_names[i])
                 ctrue <- clean_fac_col_txt(true_names[i])
-                if(cexp != ctrue){
-                    warning(str_c(
-                        "Extracted column ", i, " does not match expected ",
-                        "name. Expected: ", cexp, " Received: ", ctrue))
+                
+                # Exact match 
+                if (!detect){
+                    if(cexp != ctrue){
+                        warning(str_c(
+                            "Extracted column ", i, " does not match expected ",
+                            "name. Expected: ", cexp, " Received: ", ctrue))
+                    }
+                }
+                
+                # Case-insensitive string contains match 
+                if (detect){
+                    if(!str_detect(ctrue, paste0("(?i)", cexp))){
+                          warning(str_c(
+                            "Extracted column ", i, " does not contain expected string. ",
+                            "Expected: ", cexp, " Received: ", ctrue))
+                    }
                 }
             }
         }
     }
 }
 
-check_names <- function(DF, expected_names){
+check_names <- function(DF, expected_names, detect = FALSE){
     true_names <- names(DF)
-    basic_check(true_names, expected_names)
+    basic_check(true_names, expected_names, detect)
 }
 
 check_names_extractable <- function(df_, col_name_df){

--- a/production/scrapers/west_virginia_vaccine.R
+++ b/production/scrapers/west_virginia_vaccine.R
@@ -20,8 +20,21 @@ west_virginia_vaccine_restruct <- function(x){
     }
     
     names(df_)[1] <- "Name"
+    names(df_) <- paste(names(df_), df_[1, ], sep = "_")
+
+    check_names(df_, c("name", "county", "pop", "1st", "2nd", "johnson"), 
+                detect = TRUE)
     
-    df_
+    names(df_) <- c(
+        "Name", 
+        "Drop.County", 
+        "Drop.Population",
+        "Moderna.Initiated", 
+        "Moderna.Completed", 
+        "Johnson"
+        )
+    
+    df_[-1,]
 }
 
 west_virginia_vaccine_extract <- function(x){
@@ -29,41 +42,35 @@ west_virginia_vaccine_extract <- function(x){
     emp_idx <- first(which(str_detect(x$Name, "(?i)employee")))
     
     res_df <- x[1:(emp_idx-1),] %>%
-        rename(
-            Drop.County = "County", 
-            Drop.Population = "Pop.",
-            Moderna.Initiated = "Moderna \n(1st dose)",
-            Residents.Completed = "Johnson & Johnson \n(fully vaccinated)*") %>%
         select(!starts_with("Drop")) %>%
-        clean_scraped_df() %>%
-        mutate(Residents.Initiated = vector_sum_na_rm(
-            Residents.Completed, Moderna.Initiated)) %>%
-        select(-Moderna.Initiated) %>%
-        filter(!is.na(Residents.Completed)) %>%
-        filter(!str_detect(Name, "(?i)total")) %>%
-        filter(!str_detect(Name, "(?i)all J&J")) %>%
-        filter(!str_detect(Name, "(?i)residents")) %>%
-        clean_scraped_df()
+        clean_scraped_df() %>% 
+        mutate(Residents.Initiated = vector_sum_na_rm(Moderna.Initiated, Johnson), 
+               Residents.Completed = vector_sum_na_rm(Moderna.Completed, Johnson)) %>% 
+        filter(!across(c(Moderna.Initiated, Moderna.Completed, Johnson), ~ is.na(.x))) %>% 
+        filter(!str_detect(Name, "(?i)total")) 
     
     staff_df <- x[emp_idx:nrow(x),] %>%
-        filter(!str_detect(Name, "(?i)total")) %>%
-        select(-`Moderna \n(1st dose)`)
+        filter(!str_detect(Drop.County, "(?i)total")) %>%
+        mutate(Name = stringr::str_c(Drop.County, " staff total")) %>% 
+        rename(Staff.Population = Drop.Population) %>% 
+        select(!starts_with("Drop")) %>%
+        clean_scraped_df() %>% 
+        mutate(Staff.Initiated = vector_sum_na_rm(Moderna.Initiated, Johnson), 
+               Staff.Completed = vector_sum_na_rm(Moderna.Completed, Johnson))
     
-    names(staff_df) <- as.character(na.omit(unlist(x[emp_idx,])))
-    
-    staff_df %>%
-        select(
-            Name = `EMPLOYEES (Moderna)`, 
-            Staff.Initiated = `1st Doses`,
-            Staff.Completed = `2nd Doses`,
-            Staff.Population = `Staffing*`
-            ) %>%
-        filter(Name != "EMPLOYEES (Moderna)") %>% 
-        clean_scraped_df() %>%
-        mutate(Name = stringr::str_c(Name, " staff total")) %>% 
-        # moderna so this should work
-        mutate(Staff.Vadmin = Staff.Initiated + Staff.Completed) %>%
-        bind_rows(res_df)
+    if(nrow(res_df) != 34){
+        warning(stringr::str_c(
+            "Expected 34 resident rows, got ", nrow(res_df), 
+            ". Check raw file for rows that should/shouldn't be dropped."))
+    }
+    if(nrow(staff_df) != 4){
+        warning(stringr::str_c(
+            "Expected 4 staff rows, got ", nrow(res_df), 
+            ". Check raw file for rows that should/shouldn't be dropped."))
+    }
+
+    bind_rows(res_df, staff_df) %>% 
+        select(Name, starts_with(c("Residents.", "Staff.")))
 }
 
 #' Scraper class for general West Virginia COVID data


### PR DESCRIPTION
Adds a `detect` param to `check_names` (defaults to `FALSE`) for looser column name checks.  

And fixes the West Virginia vaccine scraper to reflect the this week's structure // can't wait for them to change the structure again next week 😭 It's a little less robust than ideal because there are so many total rows, so I added in explicit warnings if there are more rows than expected for residents and staff – not sure if this is too aggressive though. 