### PR TITLE
fix: split up wv staff jurisdictions

### DIFF
--- a/production/scrapers/west_virginia.R
+++ b/production/scrapers/west_virginia.R
@@ -71,19 +71,20 @@ west_virginia_extract <- function(x){
         sum()
     
     # see which row starts employee data
-    idb <- str_detect(
-        x$Name, "(?i)Employee") & str_detect(x$Name, "(?i)totals")
-    staff_df <- x[first(which(idb)),]
+    emp_idx <- first(which(str_detect(x$Name, "(?i)employee")))
+    staff_df <- x[emp_idx:nrow(x),] 
     names(staff_df) <- str_replace(names(staff_df), "Residents", "Staff")
     
-    staff_df %>%
-        mutate(Name = "State-Wide") %>%
+    staff_df %>% 
         select(-starts_with("Drop"), -Staff.Population, Staff.Active) %>%
-        select(-Staff.Quarantine) %>% 
-        clean_scraped_df() %>%
-        mutate(Residents.Deaths = resident_deaths) %>%
+        filter(!is.na(Staff.Confirmed)) %>% 
+        filter(!str_detect(Staff.Confirmed, "(?i)cumulative")) %>% 
+        filter(!str_detect(Name, "(?i)total")) %>% 
+        mutate(Name = str_c(clean_fac_col_txt(Name), " staff total")) %>% 
+        clean_scraped_df() %>% 
         bind_rows(fac_df) %>%
-        rename(Staff.Tested = Staff.Tadmin)
+        rename(Staff.Tested = Staff.Tadmin) %>% 
+        bind_rows(tibble(Name = "State-Wide", Residents.Deaths = resident_deaths))
 }
 
 #' Scraper class for general West Virginia COVID data


### PR DESCRIPTION
Splits up the West Virginia staff numbers so we can downstream assign jurisdiction to `state`, `county`, `youth`, etc. etc. I'll re-scrape the historical data after approved! 

<img width="636" alt="Screen Shot 2021-05-26 at 6 34 37 PM" src="https://user-images.githubusercontent.com/47676353/119744161-104c5b00-be51-11eb-83ad-a85da2edc6ec.png">

Also, here's the bunny that was distracting me while I was making this update. 

![IMG_2760](https://user-images.githubusercontent.com/47676353/119744294-4be72500-be51-11eb-9fba-c85bfe7caf33.jpeg)
