### PR TITLE
update: add ohio and north dakota population scrapers

### DIFF
--- a/production/scrapers/north_dakota_population.R
+++ b/production/scrapers/north_dakota_population.R
@@ -1,0 +1,94 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+nd_pop_crop <- function(img, crop, detect){
+
+    sub_txt <- img %>% 
+        magick::image_crop(crop) %>% 
+        magick::image_ocr() 
+    
+    if(!str_detect(sub_txt, detect)){
+        warning("Field does mot match expected text")
+    }
+    
+    out_val <- as.numeric(
+        str_c(unlist(str_extract_all(sub_txt, "[0-9]+")), collapse = ""))
+
+    if(is.na(out_val)){
+        warning("Na value extracted but not expected. Please inspect.")
+    }
+    
+    out_val
+}
+
+nd_pop_restruct <- function(x){
+    img <- magick::image_read_pdf(x) 
+    
+    # Hard code crop dimensions (LASD scraper approach)
+    bind_rows(
+        tibble(Name = "NDSP", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+460", "NDSP")), 
+        tibble(Name = "JRCC", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+670", "JRCC")), 
+        tibble(Name = "JRMU", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+790", "JRMU")), 
+        tibble(Name = "MRCC", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+1010", "MRCC")), 
+        tibble(Name = "DWCRC", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+1230", "DWCRC")), 
+        tibble(Name = "TRC", 
+               Residents.Population = nd_pop_crop(img, "700x140+20+1440", "TRC"))
+    )
+}
+
+#' Scraper class for general North Dakota population data
+#' tibble(
+#' @name nd_pop_scraper
+#' @description North Dakota posts daily pdf w/ facility-level population data. 
+#' The scraper crops out the relevant text based on position on the pdf. 
+#' 
+#' \describe{
+#'   \item{Name}{}
+#'   \item{Gender}{}
+#'   \item{Operational Capacity Daily Count}{Residents.Population}
+#' }
+
+nd_pop_scraper <- R6Class(
+    "north_dakota_population",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://www.docr.nd.gov/sites/www/files/documents/reports/FACILITY_COUNTS.pdf",
+            id = "north_dakota_population",
+            type = "pdf",
+            state = "ND",
+            jurisdiction = "state",
+            # pull the JSON data directly from the API
+            pull_func = function(x){x}, 
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = nd_pop_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = function(x){x}){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    nd_pop <- nd_pop_scraper$new(log=TRUE)
+    nd_pop$raw_data
+    nd_pop$pull_raw()
+    nd_pop$raw_data
+    nd_pop$save_raw()
+    nd_pop$restruct_raw()
+    nd_pop$restruct_data
+    nd_pop$extract_from_raw()
+    nd_pop$extract_data
+    nd_pop$validate_extract()
+    nd_pop$save_extract()
+}

--- a/production/scrapers/ohio_population.R
+++ b/production/scrapers/ohio_population.R
@@ -1,0 +1,135 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+ohio_population_pull <- function(x, exp_date = Sys.Date()){
+    # Extract all urls 
+    url_ <- x %>% 
+        xml2::read_html() %>%
+        rvest::html_nodes("a") %>%
+        rvest::html_attr("href")
+    
+    # Extract all link texts
+    link_ <- x %>%
+        xml2::read_html() %>%
+        rvest::html_nodes("a") %>%
+        rvest::html_text()
+    
+    # Get url for latest pdf 
+    tbl <- tibble(link = link_, url = url_) %>% 
+        filter(stringr::str_detect(url_, "Portals")) %>% 
+        mutate(Date = lubridate::mdy(link))
+    
+    latest_date <- max(tbl$Date)
+    error_on_date(latest_date, exp_date)
+    
+    stringr::str_c(
+        "https://drc.ohio.gov", 
+        tbl %>% 
+            filter(Date == latest_date) %>% 
+            pull(url)
+    )
+}
+
+ohio_population_restruct <- function(x){
+    list(pg1 = x %>% 
+             tabulizer::extract_tables(pages = 1, area = list(c(129, 49, 753, 564))), 
+         pg2 = x %>% 
+            tabulizer::extract_tables(pages = 2, area = list(c(45, 50, 345, 565)))
+    )
+}
+
+which(sapply(x$pop, function(z){
+    any(str_detect(z[,1], "(?i)Adult Facility"))}))
+
+
+ohio_population_extract <- function(x){
+    
+    exp <- c("", "Institution", "Count", "", "Institution", "Count") 
+    if (!all(exp == x$pg1[[1]][1,])){
+        warning(
+            "Column names not as expected. See if raw file structure changed." 
+        )
+    }
+    
+    if (!str_detect(x$pg2[[2]][nrow(x$pg2[[2]]),4], "(?i)total population")){
+        warning(
+            "Total column on second page not as expected. See if raw file structure changed." 
+        )
+    }
+    
+    total <- x$pg2[[2]][nrow(x$pg2[[2]]),5] %>% string_to_clean_numeric()
+    
+    # Hard-coding 
+    out <- tibble(
+        Name = c(
+            x$pg1[[1]][,1], 
+            x$pg1[[1]][,4], 
+            x$pg2[[2]][,1], 
+            x$pg2[[2]][,3]), 
+        Residents.Population = c(
+            x$pg1[[1]][,3], 
+            x$pg1[[1]][,6], 
+            x$pg2[[2]][,2], 
+            x$pg2[[2]][,5])
+    ) %>% 
+        filter(!str_detect(Name, "(?i)total")) %>% 
+        filter(!str_detect(Residents.Population, "(?i)count")) %>% 
+        filter(Name != "") %>% 
+        clean_scraped_df() 
+    
+    if (sum_na_rm(out$Residents.Population) != total) {
+        warning(
+            "Total doesn't match sum of facilities. See if raw file structure changed." 
+        )
+    }
+    
+    out
+}
+
+#' Scraper class for Ohio population data 
+#' 
+#' @name ohio_population_scraper
+#' @description Ohio posts weekly population reports in PDF form. The reports 
+#' also include (not scraped) population by gender and security leve, 
+#' \describe{
+#'   \item{Institition}{Name}
+#'   \item{Count}{Population}
+#' }
+
+ohio_population_scraper <- R6Class(
+    "ohio_population_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://drc.ohio.gov/reports/population",
+            id = "ohio_population",
+            type = "pdf",
+            state = "OH",
+            jurisdiction = "state",
+            pull_func = ohio_population_pull,
+            restruct_func = ohio_population_restruct,
+            extract_func = ohio_population_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction  = jurisdiction)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    ohio_population <- ohio_population_scraper$new(log=TRUE)
+    ohio_population$raw_data
+    ohio_population$pull_raw()
+    ohio_population$raw_data
+    ohio_population$save_raw()
+    ohio_population$restruct_raw()
+    ohio_population$restruct_data
+    ohio_population$extract_from_raw()
+    ohio_population$extract_data
+    ohio_population$validate_extract()
+    ohio_population$save_extract()
+}
+


### PR DESCRIPTION
Adding two particularly hacky population scrapers into the main set. 

Ohio (e.g. [here](https://drc.ohio.gov/Portals/0/1084.pdf)) is decently hard-coded / the structure is annoying. I threw in a few checks and it runs warning-free on all weekly files since 2020 at least! 

North Dakota (e.g. [here](https://www.docr.nd.gov/sites/www/files/documents/reports/FACILITY_COUNTS.pdf)) is set up like LASD. From the wayback archives that exist, it seems like this hasn't changed, so another \~we shall see~ scraper. 