### PR TITLE
update: added facility-level vaccine counts to md

### DIFF
--- a/production/scrapers/maryland_vaccine.R
+++ b/production/scrapers/maryland_vaccine.R
@@ -52,13 +52,15 @@ get_maryland_facility_vaccine_table <- function(x){
         rvest::html_nodes("div") %>%
         rvest::html_children()
     
-    dat_df <- do.call(rbind, lapply(col_dat, function(p){
+    dat_list <- lapply(col_dat, function(p){
         sapply(rvest::html_children(p), function(z){
             z %>% 
                 rvest::html_nodes("div") %>%
-                rvest::html_attr("title")})})) %>%
+                rvest::html_attr("title")})})
+
+    dat_df <- do.call(rbind, dat_list[sapply(dat_list, is.matrix)]) %>%
         as.data.frame()
-    
+
     names(dat_df) <- tab %>%
         rvest::html_node(".columnHeaders") %>%
         rvest::html_node("div") %>%

--- a/production/scrapers/maryland_vaccine.R
+++ b/production/scrapers/maryland_vaccine.R
@@ -6,8 +6,7 @@ maryland_vaccine_pull <- function(x){
         "https://app.powerbigov.us/view?r=", 
         "eyJrIjoiMjdlZjZmNzAtOGYxNS00ODA4LThhMzktOGYyZDEw", 
         "YTMwMDZkIiwidCI6IjYwYWZlOWUyLTQ5Y2QtNDliMS04ODUx", 
-        "LTY0ZGYwMjc2YTJlOCJ9&pageName=ReportSection&pageName=ReportSection", 
-        "4b1b308960abe0bc0ce7")
+        "LTY0ZGYwMjc2YTJlOCJ9&pageName=ReportSectionac5a5322ab94d53d5fca")
 
     fprof <- RSelenium::makeFirefoxProfile(list(
         browser.startup.homepage = "about:blank",
@@ -39,6 +38,43 @@ maryland_vaccine_pull <- function(x){
     base_html <- remDr$getPageSource()
     
     xml2::read_html(base_html[[1]])
+}
+
+get_maryland_facility_vaccine_table <- function(x){
+    tab <- x %>%
+        rvest::html_nodes(".tableEx") %>%
+        rvest::html_nodes(".innerContainer")
+    
+    tab <- tab[3]
+    
+    col_dat <- tab %>%
+        rvest::html_nodes(".bodyCells") %>%
+        rvest::html_nodes("div") %>%
+        rvest::html_children()
+    
+    dat_df <- do.call(rbind, lapply(col_dat, function(p){
+        sapply(rvest::html_children(p), function(z){
+            z %>% 
+                rvest::html_nodes("div") %>%
+                rvest::html_attr("title")})})) %>%
+        as.data.frame()
+    
+    names(dat_df) <- tab %>%
+        rvest::html_node(".columnHeaders") %>%
+        rvest::html_node("div") %>%
+        rvest::html_nodes("div") %>% 
+        rvest::html_attr("title") %>%
+        na.omit() %>%
+        as.vector()
+    
+    dat_df %>%
+        rename(Name = "Facility (Administered)") %>%
+        filter(!str_detect(Name, "(?i)total")) %>% 
+        mutate_all(as.character) %>% 
+        mutate_at(vars(-Name), string_to_clean_numeric) %>% 
+        filter(Name != "character(0)") %>% 
+        mutate_if(is.numeric, function(x) ifelse(is.na(x), 0, x)) %>%
+        filter(!str_detect(Name, "(?i)total"))
 }
 
 get_maryland_vaccine_table <- function(x, str){
@@ -75,20 +111,59 @@ get_maryland_vaccine_table <- function(x, str){
 maryland_vaccine_restruct <- function(x){
         
     # Need single quotes for the xpath 
-    staff <- get_maryland_vaccine_table(x, "'Staff Vaccinations'") %>% 
-        rename("Staff.Initiated" = "First Shot", 
-               "Staff.Completed" = "Second Shot")
+    staff_total <- get_maryland_vaccine_table(x, "'Staff Vaccinations'") 
+    res_total <- get_maryland_vaccine_table(x, "'Inmate Vaccinations'")
+
+    exp_staff_names <- c(
+        Staff.Initiated = "First Shot",
+        Staff.Completed = "Second Shot", 
+        Staff.Single.Drop = "Single Shot"
+    )
     
-    res <- get_maryland_vaccine_table(x, "'Inmate Vaccinations'") %>% 
-        rename("Residents.Initiated" = "First Shot", 
-               "Residents.Completed" = "Second Shot")
+    exp_res_names <- c(
+        Residents.Initiated =  "First Shot", 
+        Residents.Completed = "Second Shot"
+    )
     
-    cbind(staff, res)
+    check_names(staff_total, exp_staff_names)
+    names(staff_total) <- names(exp_staff_names)
+    
+    check_names(res_total, exp_res_names)
+    names(res_total) <- names(exp_res_names)
+    
+    staff_total <- mutate_all(staff_total, string_to_clean_numeric) %>% 
+        mutate(Name = "STATEWIDE")
+    res_total <- mutate_all(res_total, string_to_clean_numeric)
+
+    res_facility <- get_maryland_facility_vaccine_table(x)
+    
+    exp_names <- c(
+        Name = "Name", 
+        Residents.Initiated =  "First Doses Administered", 
+        Residents.First.Refusal.Drop = "First Dose Refusals", 
+        Residents.Completed = "Second Doses Adminstered", 
+        Residents.Second.Refusal.Drop = "Second Dose Refusals"
+    )
+    
+    check_names(res_facility, exp_names)
+    names(res_facility) <- names(exp_names)
+    
+    if (sum_na_rm(res_facility$Residents.Initiated) != res_total$Residents.Initiated){
+        warning("Sum of facilities does not match total. Check dashboard for changes.")
+    }
+    
+    if (sum_na_rm(res_facility$Residents.Completed) != res_total$Residents.Completed){
+        warning("Sum of facilities does not match total. Check dashboard for changes.")
+    }
+    
+    bind_rows(res_facility, staff_total)
 }
 
 maryland_vaccine_extract <- function(x){
     x %>%
-        mutate(Name = "STATEWIDE") %>% 
+        mutate(Staff.Initiated = Staff.Initiated + Staff.Single.Drop, 
+               Staff.Completed = Staff.Completed + Staff.Single.Drop) %>%  
+        select(-ends_with(("Drop"))) %>% 
         clean_scraped_df() 
 }
 
@@ -96,14 +171,16 @@ maryland_vaccine_extract <- function(x){
 #' 
 #' @name maryland_vaccine_scraper
 #' @description Vaccine data from MD is pulled from the fourth table on their Power BI 
-#' dashboard. Statewide totals for first and second shot for staff and incarcerated 
-#' people are reported. The dashboard also lists vaccine requirement status, 
-#' eligibility group, and the number of eligible inmates. 
+#' dashboard. Statewide totals for first and second shot for staff and facility 
+#' data (as of June 2021) for incarcerated people are reported. 
+#' The dashboard also lists first and second dose refusals by facility, vaccine 
+#' requirement status, eligibility group, and the number of eligible inmates. 
 #' \describe{
 #'   \item{Staff Vaccinations First Shot}{}
 #'   \item{Staff Vaccinations Second Shot}{}
+#'   \item{Staff Vaccinations Single Shot}{}
 #'   \item{Inmate Vaccinations First Shot}{}
-#'   \item{Inmate Vaccinations SEcond Shot}{}
+#'   \item{Inmate Vaccinations Second Shot}{}
 #' }
 
 maryland_vaccine_scraper <- R6Class(


### PR DESCRIPTION
Replaced the statewide vaccine totals from Maryland with the facility-level data and added a few more checks (mostly to catch if they start reporting one-shot vaccine data separately). 