### PR TITLE
Date checkout revamp

### DIFF
--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -187,15 +187,6 @@ generic_scraper <- R6Class(
             )
             
             if(self$log){
-
-                if(file.exists(self$err_log)){
-                    if(str_detect(read_file(self$err_log), "ERROR ")){
-                        tryLog(warning(
-                            "Log file with errors exists.",
-                            "Not going to pull data."))
-                        return()
-                    }
-                }
                 
                 if(self$date != Sys.Date() & !.dated_pull){
                     tryLog(self$raw_data <- valid_types[[self$type]](url))

--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -48,7 +48,9 @@ generic_scraper <- R6Class(
         err_log = NULL,
         raw_dest = NULL,
         extract_dest = NULL,
+        days_late_dest = NULL,
         permalink = NULL,
+        days_late = NULL,
         jurisdiction = NULL,
         initialize = function(
             url, id, pull_func, type, restruct_func, extract_func, log,
@@ -72,6 +74,7 @@ generic_scraper <- R6Class(
             self$restruct_data = NULL
             self$extract_data = NULL
             self$permalink = NULL
+            self$days_late = NULL
             self$pull_func = pull_func
             self$restruct_func = restruct_func
             self$extract_func = extract_func
@@ -88,6 +91,8 @@ generic_scraper <- R6Class(
                 "./results/raw_files/", self$date, "_", id, valid_types[type])
             self$extract_dest = paste0(
                 "./results/extracted_data/", self$date, "_", id, ".csv")
+            self$days_late_dest = paste0(
+                "./results/last_update/", self$date, "_", id, ".csv")
             
             if(!dir.exists("./results/")){
                 dir.create("./results/")
@@ -103,6 +108,10 @@ generic_scraper <- R6Class(
             
             if(!dir.exists("./results/log_files")){
                 dir.create("./results/log_files")
+            }
+            
+            if(!dir.exists("./results/last_update")){
+                dir.create("./results/last_update")
             }
             
             # initiate logger
@@ -146,10 +155,10 @@ generic_scraper <- R6Class(
             }
             
             if(self$log){
-                tryLog(self$check_date(url))
+                tryLog(self$days_late <- self$check_date(url))
             }
             else{
-                self$check_date(url)
+                self$days_late <- self$check_date(url)
             }
         },
         
@@ -287,6 +296,24 @@ generic_scraper <- R6Class(
                     mutate(id = self$id, source = self$url) %>%
                     mutate(jurisdiction = self$jurisdiction) %>%
                     write_csv(self$extract_dest)
+            }
+            invisible(self)
+        },
+        
+        write_days_late = function(){
+            if(self$log){
+                tryLog(tibble(
+                    State = self$state, Date = self$date, id = self$id,
+                    source = self$url, jurisdiction = self$jurisdiction) %>%
+                    mutate(days_late = self$days_late) %>%
+                    write_csv(self$days_late_dest))
+            }
+            else{
+                tibble(
+                    State = self$state, Date = self$date, id = self$id,
+                    source = self$url, jurisdiction = self$jurisdiction) %>%
+                    mutate(days_late = self$days_late) %>%
+                    write_csv(self$days_late_dest)
             }
             invisible(self)
         },

--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -491,6 +491,7 @@ generic_scraper <- R6Class(
             self$pull_raw()
             self$save_raw()
             self$run_check_date()
+            self$write_days_late()
             self$restruct_raw()
             self$extract_from_raw()
             self$validate_extract()

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -73,7 +73,7 @@ check_names_extractable <- function(df_, col_name_df){
     }
 }
 
-error_on_date <- function(date, expected_date, days = 7, warning = FALSE){
+error_on_date <- function(date, expected_date, days = 30, warning = FALSE){
   days_late <- abs(as.numeric(date - expected_date))
   fail <- days_late > days
     

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -73,18 +73,14 @@ check_names_extractable <- function(df_, col_name_df){
     }
 }
 
-error_on_date <- function(date, expected_date, days = 30, warning = FALSE){
-  days_late <- abs(as.numeric(date - expected_date))
-  fail <- days_late > days
-    
-    if(fail & warning){
+error_on_date <- function(date, expected_date, days = 30){
+    days_late <- abs(as.numeric(date - expected_date))
+    fail <- days_late > days
+
+    if(fail){
         warning(str_c("Date is more than ", days, " different from expected"))
     }
 
-    else if(fail){
-        stop(str_c("Date is more than ", days, " different from expected"))
-    }
-  
     return(days_late)
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -74,7 +74,8 @@ check_names_extractable <- function(df_, col_name_df){
 }
 
 error_on_date <- function(date, expected_date, days = 7, warning = FALSE){
-    fail <- abs(as.numeric(date - expected_date)) > days
+  days_late <- abs(as.numeric(date - expected_date))
+  fail <- days_late > days
     
     if(fail & warning){
         warning(str_c("Date is more than ", days, " different from expected"))
@@ -83,6 +84,8 @@ error_on_date <- function(date, expected_date, days = 7, warning = FALSE){
     else if(fail){
         stop(str_c("Date is more than ", days, " different from expected"))
     }
+  
+    return(days_late)
 }
 
 rename_extractable <- function(df_, col_name_df){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -657,7 +657,11 @@ sync_remote_files <- function(raw = FALSE){
     system(str_c(
         "rsync --perms --chmod=u+rwx -rtvu --progress results/log_files/ ",
         "ucla:/srv/shiny-server/scraper_data/log_files/"))
-    
+
+    system(str_c(
+      "rsync --perms --chmod=u+rwx -rtvu --progress results/last_update/ ",
+      "ucla:/srv/shiny-server/scraper_data/last_update/"))
+
     if(raw){
         system(str_c(
             "rsync --perms --chmod=u+rwx -rtvu --progress results/raw_files/ ",

--- a/production/pre_run.R
+++ b/production/pre_run.R
@@ -25,7 +25,9 @@ if(length(missing_packages) != 0){
 }
 
 # delete local folders if they exist
-sc_dirs <- paste0("results/", c("log_files/", "extracted_data/", "raw_files/"))
+sc_dirs <- paste0(
+    "results/",
+    c("log_files/", "extracted_data/", "raw_files/", "last_update/"))
 for(di in sc_dirs){
     if(dir.exists(di)){
         unlink(di, recursive = TRUE)


### PR DESCRIPTION
New framework for saving how many days late a particular data point is. The framework changes are as follows.

1. Have error on date return an integer value when it does not error out (error value now changed to 30 days)
2. Assign this value to an attribute of the relevant scraper
3. Write this value to a file per scraper in a new folder `./results/last_update/`
4. Sync data to the remote server

This pipeline will only occur in the normal scraper pipeline and not any of the historical pipelines.