### PR TITLE
chore: update scripts for date cutoff migration

### DIFF
--- a/reports/post_diagnostics.Rmd
+++ b/reports/post_diagnostics.Rmd
@@ -23,7 +23,7 @@ The table below summarizes the scrapers that yielded errors and warnings. Highli
 
 ``` {r echo = F, warning = F}
 # Read latest facility data 
-new_df <- read_scrape_data(all_dates = FALSE, window = 31)
+new_df <- read_scrape_data(all_dates = FALSE)
 
 # Get all log files from the latest run 
 latest_date <- max(new_df$Date) %>% 
@@ -146,7 +146,7 @@ This compares to the state-aggregated totals in `state_aggregate_counts.csv` whi
 
 ```{r check_previous_state, echo = F, message = F, warning = F}
 # Read latest statewide data 
-new_state_df <- behindbarstools::calc_aggregate_counts(state = TRUE, window = 31)
+new_state_df <- behindbarstools::calc_aggregate_counts(state = TRUE)
 
 # Read old data 
 old_state_df <- stringr::str_c(


### PR DESCRIPTION
1. No more `window`
2. No longer printing totals to the console since that's what the diagnostics script is for 
3. Linter made a few two spaces to four spaces updates 

Holding off on the bigger changes related to [this](https://github.com/uclalawcovid19behindbars/data/pull/25) (renaming files, writing historical files) until we let Hyperobjekt + CDC know, but this will at least let `post_run.R` run without errors to run the scrapers on Friday! 