### PR TITLE
feat: add manual scrapers for info from contacting agencies

### DIFF
--- a/production/scrapers/alaska_manual.R
+++ b/production/scrapers/alaska_manual.R
@@ -1,0 +1,91 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+alaska_manual_check_date <- function(x, date = Sys.Date()){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "AK", col_types = "cDccc") %>%
+        pull(Date) %>%
+        max(na.rm = TRUE) %>%
+        error_on_date(date)
+}
+
+alaska_manual_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "AK", col_types = "cDccc")
+}
+
+alaska_manual_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+alaska_manual_extract <- function(x, exp_date = Sys.Date()){
+    
+    check_names(x, c(
+        "State",
+        "Date",
+        "Name", 
+        "Staff.Confirmed", 
+        "Staff.Deaths")
+    )
+    
+    x %>%
+        select(Name, Staff.Confirmed, Staff.Deaths) %>% 
+        {suppressWarnings(mutate_at(., vars(starts_with("Res")), as.numeric))} %>%
+        {suppressWarnings(mutate_at(., vars(starts_with("Staff")), as.numeric))} %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for Alaska COVID data collected directly from the DOC 
+#' 
+#' @name alaska_manual_scraper
+#' @description Data on staff confirmed and staff recovered collected directly from
+#' the Alaska DOC. 
+#' \describe{
+#'   \item{Staff.Confirmed}{}
+#'   \item{Staff.Deaths}{}
+#' }
+
+alaska_manual_scraper <- R6Class(
+    "alaska_manual_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Alaska Department of Corrections",
+            id = "alaska_manual",
+            type = "manual",
+            state = "AK",
+            jurisdiction = "state",
+            check_date = alaska_manual_check_date,
+            # pull the JSON data directly from the API
+            pull_func = alaska_manual_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = alaska_manual_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = alaska_manual_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    alaska_manual <- alaska_manual_scraper$new(log=TRUE)
+    alaska_manual$run_check_date()
+    alaska_manual$raw_data
+    alaska_manual$pull_raw()
+    alaska_manual$raw_data
+    alaska_manual$save_raw()
+    alaska_manual$restruct_raw()
+    alaska_manual$restruct_data
+    alaska_manual$extract_from_raw()
+    alaska_manual$extract_data
+    alaska_manual$validate_extract()
+    alaska_manual$save_extract()
+}

--- a/production/scrapers/connecticut_manual.R
+++ b/production/scrapers/connecticut_manual.R
@@ -1,0 +1,91 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+ct_manual_check_date <- function(x, date = Sys.Date()){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "CT", col_types = "cDccc") %>%
+        pull(Date) %>%
+        max(na.rm = TRUE) %>%
+        error_on_date(date)
+}
+
+ct_manual_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "CT", col_types = "cDccc")
+}
+
+ct_manual_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+ct_manual_extract <- function(x, exp_date = Sys.Date()){
+    
+    check_names(x, c(
+        "State",
+        "Date",
+        "Name", 
+        "Staff.Confirmed", 
+        "Staff.Recovered")
+    )
+    
+    x %>%
+        select(Name, Staff.Confirmed, Staff.Recovered) %>% 
+        {suppressWarnings(mutate_at(., vars(starts_with("Res")), as.numeric))} %>%
+        {suppressWarnings(mutate_at(., vars(starts_with("Staff")), as.numeric))} %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for Connecticut COVID data collected directly from the DOC 
+#' 
+#' @name connecticut_manual_scraper
+#' @description Data on staff confirmed and staff recovered collected directly from
+#' the Connecticut DOC. 
+#' \describe{
+#'   \item{Staff.Confirmed}{}
+#'   \item{Staff.Recovered}{}
+#' }
+
+connecticut_manual_scraper <- R6Class(
+    "connecticut_manual_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Connecticut Department of Corrections",
+            id = "connecticut_manual",
+            type = "manual",
+            state = "CT",
+            jurisdiction = "state",
+            check_date = ct_manual_check_date,
+            # pull the JSON data directly from the API
+            pull_func = ct_manual_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = ct_manual_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = ct_manual_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    ct_manual <- connecticut_manual_scraper$new(log=TRUE)
+    ct_manual$run_check_date()
+    ct_manual$raw_data
+    ct_manual$pull_raw()
+    ct_manual$raw_data
+    ct_manual$save_raw()
+    ct_manual$restruct_raw()
+    ct_manual$restruct_data
+    ct_manual$extract_from_raw()
+    ct_manual$extract_data
+    ct_manual$validate_extract()
+    ct_manual$save_extract()
+}

--- a/production/scrapers/illinois_manual.R
+++ b/production/scrapers/illinois_manual.R
@@ -1,0 +1,90 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+illinois_manual_check_date <- function(x, date = Sys.Date()){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "IL", col_types = "cDcc") %>%
+        pull(Date) %>%
+        max(na.rm = TRUE) %>%
+        error_on_date(date)
+}
+
+illinois_manual_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "IL", col_types = "cDcc")
+}
+
+illinois_manual_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+illinois_manual_extract <- function(x, exp_date = Sys.Date()){
+    
+    check_names(x, c(
+        "State",
+        "Date",
+        "Name", 
+        "Residents.Deaths")
+    )
+    
+    x %>%
+        select(Name, Residents.Deaths) %>% 
+        {suppressWarnings(mutate_at(., vars(starts_with("Res")), as.numeric))} %>%
+        {suppressWarnings(mutate_at(., vars(starts_with("Staff")), as.numeric))} %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for Illinois COVID data collected directly from the DOC 
+#' 
+#' @name illinois_manual_scraper
+#' @description Data on staff confirmed and staff deaths collected directly from
+#' the Illinois DOC. 
+#' \describe{
+#'   \item{Staff.Confirmed}{}
+#'   \item{Staff.Deaths}{}
+#' }
+
+illinois_manual_scraper <- R6Class(
+    "illinois_manual_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Illinois Department of Corrections",
+            id = "illinois_manual",
+            type = "manual",
+            state = "IL",
+            jurisdiction = "state",
+            check_date = illinois_manual_check_date,
+            # pull the JSON data directly from the API
+            pull_func = illinois_manual_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = illinois_manual_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = illinois_manual_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    illinois_manual <- illinois_manual_scraper$new(log=TRUE)
+    illinois_manual$run_check_date()
+    illinois_manual$raw_data
+    illinois_manual$pull_raw()
+    illinois_manual$raw_data
+    illinois_manual$save_raw()
+    illinois_manual$restruct_raw()
+    illinois_manual$restruct_data
+    illinois_manual$extract_from_raw()
+    illinois_manual$extract_data
+    illinois_manual$validate_extract()
+    illinois_manual$save_extract()
+}

--- a/production/scrapers/vermont_deaths_manual.R
+++ b/production/scrapers/vermont_deaths_manual.R
@@ -1,0 +1,89 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+vermont_deaths_manual_check_date <- function(x, date = Sys.Date()){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "VT Deaths", col_types = "cDcc") %>%
+        pull(Date) %>%
+        max(na.rm = TRUE) %>%
+        error_on_date(date)
+}
+
+vermont_deaths_manual_pull <- function(x){
+    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
+        googlesheets4::read_sheet(sheet = "VT Deaths", col_types = "cDcc")
+}
+
+vermont_deaths_manual_restruct <- function(x){
+    x %>%
+        filter(!is.na(Date)) %>% 
+        filter(Date == max(Date))
+}
+
+vermont_deaths_manual_extract <- function(x, exp_date = Sys.Date()){
+    
+    check_names(x, c(
+        "State",
+        "Date",
+        "Name", 
+        "Residents.Deaths")
+    )
+    
+    x %>%
+        select(Name, Residents.Deaths) %>% 
+        {suppressWarnings(mutate_at(., vars(starts_with("Res")), as.numeric))} %>%
+        {suppressWarnings(mutate_at(., vars(starts_with("Staff")), as.numeric))} %>%
+        clean_scraped_df()
+}
+
+#' Scraper class for Vermont COVID data collected directly from the DOC 
+#' 
+#' @name vermont_deaths_manual_scraper
+#' @description Data on staff confirmed and staff recovered collected directly from
+#' the Vermont DOC. 
+#' \describe{
+#'   \item{Residents.Deaths}{}
+#' }
+
+vermont_deaths_manual_scraper <- R6Class(
+    "vermont_deaths_manual_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Vermont Department of Corrections",
+            id = "vermont_deaths_manual",
+            type = "manual",
+            state = "VT",
+            jurisdiction = "state",
+            check_date = vermont_deaths_manual_check_date,
+            # pull the JSON data directly from the API
+            pull_func = vermont_deaths_manual_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = vermont_deaths_manual_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = vermont_deaths_manual_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    vermont_deaths_manual <- vermont_deaths_manual_scraper$new(log=TRUE)
+    vermont_deaths_manual$run_check_date()
+    vermont_deaths_manual$raw_data
+    vermont_deaths_manual$pull_raw()
+    vermont_deaths_manual$raw_data
+    vermont_deaths_manual$save_raw()
+    vermont_deaths_manual$restruct_raw()
+    vermont_deaths_manual$restruct_data
+    vermont_deaths_manual$extract_from_raw()
+    vermont_deaths_manual$extract_data
+    vermont_deaths_manual$validate_extract()
+    vermont_deaths_manual$save_extract()
+}


### PR DESCRIPTION
Simple scrapers to integrate the info Michael is getting from contacting DOCs. 

* Set up new tabs in the [manual Google Sheet](https://docs.google.com/spreadsheets/d/1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ/edit#gid=1527592402) in a separate section 
* Set up straightforward manual scrapers 