### PR TITLE
Manual rebuild of server data to prevent `read_scrape_data` errors

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -741,3 +741,7 @@ hist_config_update <- function(df){
       "rsync --perms --chmod=u+rwx -rtvu --progress ", tf,
       " ucla:/srv/shiny-server/scraper_data/summary_data/hist_records.csv"))
 }
+
+summarize_remote_data <- function(){
+  system("ssh ucla '/srv/shiny-server/scraper_utilities/summarize.R'")
+}

--- a/production/historical_scrape/README_historical.md
+++ b/production/historical_scrape/README_historical.md
@@ -23,3 +23,5 @@ RScript production/historical_scrape/main_historical.R --config production/histo
 This will populate the `results` directory with the raw, extracted, and log files. 
 
 4. **Sync files**: Sync your files with the remote database by calling `sync_remote_files(raw = TRUE)` within the console. 
+
+5. **Summarize server data**: Rebuild the aggregated data on the server using the command `summarize_remote_data()`.  

--- a/production/post_run.R
+++ b/production/post_run.R
@@ -5,7 +5,8 @@ source("./R/utilities.R")
 
 # Sync raw, extracted, and log files
 sync_remote_files(TRUE)
-Sys.sleep(2*60)
+# summarize the remote files
+summarize_remote_data()
 
 # Generate and sync diagnostics
 generate_diagnostics()

--- a/production/redo_scrape/README_redo.md
+++ b/production/redo_scrape/README_redo.md
@@ -26,6 +26,7 @@ rm(list=ls())
 library(tidyverse)
 source("./R/utilities.R")
 sync_remote_files(FALSE)
+summarize_remote_data()
 ```
 
 We specify `FALSE`, the default setting, here for the `raw` parameter as to avoid re-writing the raw files from which extractions were made. However, it will not break anything if the parameter accidently set to `TRUE`. 


### PR DESCRIPTION
Adds a new function to the pipeline `summarize_remote_data` which rebuilds the aggregated scraped data on the server. Prior to this, the file was rebuilt every 5 minutes on the server automatically but this lead to issues where sometimes the file wouldn't exist and `read_scrape_data` would fail because it was being rewritten. Now the file will rebuild only once a day at 12:05 AM EST and we can use the `summarize_remote_data`  function to trigger another rebuild.