### PR TITLE
update: use TJI data for Texas deaths 

### DIFF
--- a/production/scrapers/texas.R
+++ b/production/scrapers/texas.R
@@ -27,8 +27,6 @@ texas_restruct <- function(x){
 
 texas_extract <- function(x){
     x %>%
-        mutate(Residents.Deaths = Offender_Deceased__Presumed_COVID + 
-                   Offender_Deceased_Confirmed_COVID) %>%
         mutate(Residents.Quarantine = 
                    Medical_Restriction + Medical_Isolation) %>%
         select(

--- a/production/scrapers/texas_deaths_tji.R
+++ b/production/scrapers/texas_deaths_tji.R
@@ -1,0 +1,93 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+texas_deaths_tji_pull <- function(x){
+    "1mOS1wggvyRUOpI-u2VabmnQ1yJPPEgOc2zdZjWxbAwQ" %>% 
+        googlesheets4::read_sheet(
+            sheet = "Inmate Deaths", 
+            col_types = "cDDccccccccccccccc")
+}
+
+texas_deaths_tji_restruct <- function(x){
+    x %>% 
+        filter(FacilityType %in% c("State Prison")) %>% 
+        group_by(Facility) %>% 
+        summarise(Residents.Deaths = n()) 
+}
+
+texas_deaths_tji_extract <- function(x){
+    x %>%
+        select(Name = Facility,
+               Residents.Deaths) %>% 
+        clean_scraped_df()
+}
+
+#' Scraper class for Texas deaths data from the Texas Justice Initiative
+#' 
+#' @name texas_deaths_tji_scraper
+#' @description Data pulled from Texas Justice Initiative. Data from TDCJ has 
+#' not been reliable, so we pull data on deaths in custody from TJI instead. 
+#' \describe{
+#'   \item{no}{}
+#'   \item{DateofDeath}{}
+#'   \item{Date Entered}{}
+#'   \item{Name}{}
+#'   \item{Gender}{}
+#'   \item{Race}{}
+#'   \item{Age}{}
+#'   \item{FacilityType}{}
+#'   \item{Facility}{}
+#'   \item{City}{}
+#'   \item{County}{}
+#'   \item{Geolocation}{}
+#'   \item{source}{}
+#'   \item{CDR link}{}
+#'   \item{CDR summary}{}
+#'   \item{CDR medical cause}{}
+#'   \item{media}{}
+#'   \item{Sentencing County}{}
+#' }
+
+texas_deaths_tji_scraper <- R6Class(
+    "texas_deaths_tji_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "https://texasjusticeinitiative.org/publications/covid-deaths-in-texas",
+            id = "texas_deaths_tji",
+            type = "csv",
+            state = "TX",
+            jurisdiction = "state",
+            check_date = NULL,
+            # pull the JSON data directly from the API
+            pull_func = texas_deaths_tji_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = texas_deaths_tji_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = texas_deaths_tji_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    texas_deaths_tji <- texas_deaths_tji_scraper$new(log=FALSE)
+    texas_deaths_tji$run_check_date()
+    texas_deaths_tji$raw_data
+    texas_deaths_tji$pull_raw()
+    texas_deaths_tji$raw_data
+    texas_deaths_tji$save_raw()
+    texas_deaths_tji$restruct_raw()
+    texas_deaths_tji$restruct_data
+    texas_deaths_tji$extract_from_raw()
+    texas_deaths_tji$extract_data
+    texas_deaths_tji$validate_extract()
+    texas_deaths_tji$save_extract()
+}
+

--- a/production/scrapers/texas_deaths_tji.R
+++ b/production/scrapers/texas_deaths_tji.R
@@ -10,24 +10,25 @@ texas_deaths_tji_pull <- function(x){
 
 texas_deaths_tji_restruct <- function(x){
     x_ <- x %>% 
-        filter(str_detect(FacilityType, "(?i)state")) 
+        filter(str_detect(FacilityType, "(?i)state|county")) 
     
     fac_types <- x_ %>% 
         distinct(FacilityType) %>% 
         pull()
 
     for (i in fac_types){
-        if (!i %in% c("State Prison", "State Jail")){
+        if (!i %in% c("State Prison", "State Jail", "County Jail")){
             stop(paste("Unexpected facility type:", i))
         }
     }
     
-    if (length(fac_types) != 2){
+    if (length(fac_types) != 3){
         stop(paste("Should have pulled State Prison and State Jail facilities.", 
                     "Instead pulled:", toString(fac_types)))
     }
 
     x_ %>% 
+        mutate(Facility = paste(Facility, FacilityType)) %>% 
         group_by(Facility) %>% 
         summarise(Residents.Deaths = n()) 
 }

--- a/production/scrapers/texas_deaths_tji.R
+++ b/production/scrapers/texas_deaths_tji.R
@@ -9,8 +9,25 @@ texas_deaths_tji_pull <- function(x){
 }
 
 texas_deaths_tji_restruct <- function(x){
-    x %>% 
-        filter(FacilityType %in% c("State Prison")) %>% 
+    x_ <- x %>% 
+        filter(str_detect(FacilityType, "(?i)state")) 
+    
+    fac_types <- x_ %>% 
+        distinct(FacilityType) %>% 
+        pull()
+
+    for (i in fac_types){
+        if (!i %in% c("State Prison", "State Jail")){
+            stop(paste("Unexpected facility type:", i))
+        }
+    }
+    
+    if (length(fac_types) != 2){
+        stop(paste("Should have pulled State Prison and State Jail facilities.", 
+                    "Instead pulled:", toString(fac_types)))
+    }
+
+    x_ %>% 
         group_by(Facility) %>% 
         summarise(Residents.Deaths = n()) 
 }

--- a/production/scrapers/texas_statewide.R
+++ b/production/scrapers/texas_statewide.R
@@ -29,8 +29,6 @@ texas_statewide_restruct <- function(x){
 texas_statewide_extract <- function(x){
     x %>%
         mutate(Name = "State-Wide", 
-               Residents.Deaths = Offender_Deceased__Presumed_COVID + 
-                   Offender_Deceased_Confirmed_COVID, 
                Residents.Confirmed = Offender_Total_Positive_Cases, 
                Residents.Tadmin = Offender_Total_Tests, 
                Residents.Active = Offender_Active_Cases, 


### PR DESCRIPTION
Proposing a really simple solution, where we just stop scraping deaths data from TDCJ and start pulling facility-level deaths data from TJI one day (so don't historically replace TDCJ data with TJI). So just one new scraper, and removing a few lines from the existing Texas scrapers. 

Other comments:  
* We're still archiving TDCJ data through the raw jsons incase we want to switch back at any point  
* Since TJI posts historical data, there's not a ton of value added by us integrating it 
* We're not reporting deaths on the website time-series dashboard, so I think it's fine to just switch sources one day 
* I think we should document the switch on GitHub (ReadMe and wiki page) and through the scorecard asterisk on the Texas state page on the website 

I'll also have to add ~60 spellings to the crosswalk, which I'll do once this approach gets sign-off. 

Re: jails in Texas, the number of deaths TJI is reporting in the `County Jail`, `State Jail`, and `Private Jail` categories (47) is less than the number TCJS was reporting (52) for some reason? As a result, I'm inclined to not build a new scraper for deaths inside jails in Texas from TJI data. 