### PR TITLE
feat: texas vaccine and mississippi records scrapers 

### DIFF
--- a/production/historical_scrape/historical_scrapers/historical_texas_vaccine_records.R
+++ b/production/historical_scrape/historical_scrapers/historical_texas_vaccine_records.R
@@ -1,0 +1,97 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+historical_tx_vaccine_records_pull <- function(x, date){
+    "/tmp/sel_dl/Responsive Information - Vaccination Rates.pdf"
+}
+
+historical_tx_vaccine_records_restruct <- function(x){
+    bind_rows(
+        tabulizer::extract_tables(x, pages = 1) %>% 
+            as.data.frame(), 
+        tabulizer::extract_tables(x, pages = 2) %>% 
+            as.data.frame()
+    )
+}
+
+historical_tx_vaccine_records_extract <- function(x){
+    
+    names(x) <- c(
+        "Name", 
+        "Staff.Population", 
+        "Residents.Population", 
+        "Staff.Initiated", 
+        "Residents.Initiated", 
+        "Staff.External.Drop", 
+        "Staff.Pct.Drop", 
+        "Residents.Pct.Drop", 
+        "Total.Pct.Drop", 
+        "Total.Needed.Drop"
+        )
+    
+    x %>%
+        clean_scraped_df() %>% 
+        mutate(Staff.Initiated = Staff.Initiated + Staff.External.Drop) %>% 
+        select(-ends_with("Drop"))
+}
+
+#' Scraper class for general Texas vaccine data from records request 
+#' 
+#' @name historical_texas_vaccine_records_scraper
+#' @description Facility-level vaccine data provided by the DOC via a records request. 
+#' \describe{
+#'   \item{Unit}{}
+#'   \item{Total Staff Population}{}
+#'   \item{Total Inmate Population}{}
+#'   \item{Total Staff Vaccinated}{}
+#'   \item{Total Inmate Vaccinated}{}
+#'   \item{Total External Staff Vaccinated}{}
+#'   \item{Total Staff Vaccinated %}{}
+#'   \item{Total Inmate Vaccinated %}{}
+#'   \item{Total Vaccinated %}{}
+#'   \item{Total Vaccinated Needed}{}
+#' }
+
+historical_tx_vaccine_records_scraper <- R6Class(
+    "historical_tx_vaccine_records_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Texas Department of Criminal Justice Records Response",
+            id = "historical_texas_vaccine_records",
+            type = "pdf",
+            state = "TX",
+            jurisdiction = "state",
+            check_date = NULL,
+            # pull the JSON data directly from the API
+            pull_func = historical_tx_vaccine_records_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = historical_tx_vaccine_records_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = historical_tx_vaccine_records_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = NULL)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    historical_tx_vaccine_records <- historical_tx_vaccine_records_scraper$new(log=FALSE)
+    historical_tx_vaccine_records$raw_data
+    historical_tx_vaccine_records$reset_date(date = "2021-09-16")
+    historical_tx_vaccine_records$pull_raw(date = historical_tx_vaccine_records$date, .dated_pull = TRUE)
+    historical_tx_vaccine_records$raw_data
+    historical_tx_vaccine_records$save_raw()
+    historical_tx_vaccine_records$restruct_raw()
+    historical_tx_vaccine_records$restruct_data
+    historical_tx_vaccine_records$extract_from_raw()
+    historical_tx_vaccine_records$extract_data
+    historical_tx_vaccine_records$validate_extract()
+    historical_tx_vaccine_records$save_extract()
+}
+

--- a/production/scrapers/defunct/mississippi_manual.R
+++ b/production/scrapers/defunct/mississippi_manual.R
@@ -10,8 +10,7 @@ ms_manual_check_date <- function(x, date = Sys.Date()){
 }
 
 ms_manual_pull <- function(x){
-    "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
-        googlesheets4::read_sheet(sheet = "MS Deaths", col_types = "cDcc")
+    stop_defunct_scraper(x)
 }
 
 ms_manual_restruct <- function(x){

--- a/production/scrapers/mississippi_records.R
+++ b/production/scrapers/mississippi_records.R
@@ -1,0 +1,129 @@
+source("./R/generic_scraper.R")
+source("./R/utilities.R")
+
+mississippi_records_pull <- function(x){
+    readxl::read_excel("results/manual/COVID-19 DAILY REPORT VitalCore 090321.xlsx")
+}
+
+mississippi_records_restruct <- function(x){
+    x %>% 
+        janitor::row_to_names(row_number = 2)
+}
+
+mississippi_records_extract <- function(x){
+    
+    exp_names <- c(
+        "FACILITY", 
+        NA, 
+        "TOTAL POSITIVES", 
+        "TOTAL NEGATIVES", 
+        "TOTAL TESTED", 
+        "TOTAL DEATHS R/T COVID", 
+        "CURRENT ACTIVE", 
+        "HOSPITALIZED", 
+        "Inmates 1st dose", 
+        "% 1st Dose", 
+        "Inmates 2nd Dose", 
+        "% 2nd Dose" 
+    )
+    
+    check_names(x, exp_names)
+    
+    names(x) <- c(
+        "Type.Drop", 
+        "Name", 
+        "Residents.Confirmed", 
+        "Residents.Negative", 
+        "Residents.Tested", 
+        "Residents.Deaths", 
+        "Residents.Active.Drop", # Dropping bc unclear how often will be updated
+        "Residents.Hospitalized.Drop", 
+        "Residents.Initiated", 
+        "Residents.Initiated.Pct.Drop", 
+        "Residents.Completed", 
+        "Residents.Completed.Pct.Drop"
+    )
+    
+    x_ <- x %>% 
+        mutate(Name = coalesce(Name, Type.Drop)) %>% 
+        filter(!is.na(Residents.Tested)) %>% 
+        select(-ends_with("Drop")) %>% 
+        {suppressWarnings(mutate_at(., vars(-Name), as.numeric))}
+    
+    fac_ <- x_ %>% 
+        filter(!str_detect(Name, "(?i)total"))
+
+    tot_ <- x_ %>% 
+        filter(str_detect(Name, "(?i)total")) 
+    
+    for (i in 2:length(fac_)){ # Start at 2 to skip Name column 
+        if (sum_na_rm(fac_[,i]) != sum_na_rm(tot_[,i])){
+            stop(paste("Total for", names(fac_[i]), "doesn't match sum of facilities.", 
+                       "Check for issues with numeric parsing."))
+        }
+    }
+    
+    fac_
+}
+
+#' Scraper class for Mississippi COVID data from records request 
+#' 
+#' @name mississippi_records_scraper
+#' @description MS provides data for a number of facilities through a pdf
+#' however minimal data is provided for each facility.
+#' \describe{
+#'   \item{Facility}
+#'   \item{Total Positives}
+#'   \item{Total Negatives}
+#'   \item{Total Tested}
+#'   \item{Total Deaths R/T COVID}
+#'   \item{Current Active}
+#'   \item{Hospitalized}
+#'   \item{Inmate 1st Dose}
+#'   \item{% 1st Dose}
+#'   \item{Inmates 2nd Dose}
+#'   \item{% 2nd Dose}
+#' }
+
+mississippi_records_scraper <- R6Class(
+    "mississippi_records_scraper",
+    inherit = generic_scraper,
+    public = list(
+        log = NULL,
+        initialize = function(
+            log,
+            url = "Mississippi Department of Corrections",
+            id = "mississippi_records",
+            type = "csv",
+            state = "MS",
+            jurisdiction = "state",
+            check_date = NULL,
+            # pull the JSON data directly from the API
+            pull_func = mississippi_records_pull,
+            # restructuring the data means pulling out the data portion of the json
+            restruct_func = mississippi_records_restruct,
+            # Rename the columns to appropriate database names
+            extract_func = mississippi_records_extract){
+            super$initialize(
+                url = url, id = id, pull_func = pull_func, type = type,
+                restruct_func = restruct_func, extract_func = extract_func,
+                log = log, state = state, jurisdiction = jurisdiction,
+                check_date = check_date)
+        }
+    )
+)
+
+if(sys.nframe() == 0){
+    mississippi_records <- mississippi_records_scraper$new(log=TRUE)
+    mississippi_records$run_check_date()
+    mississippi_records$raw_data
+    mississippi_records$pull_raw()
+    mississippi_records$raw_data
+    mississippi_records$save_raw()
+    mississippi_records$restruct_raw()
+    mississippi_records$restruct_data
+    mississippi_records$extract_from_raw()
+    mississippi_records$extract_data
+    mississippi_records$validate_extract()
+    mississippi_records$save_extract()
+}

--- a/production/scrapers/mississippi_records.R
+++ b/production/scrapers/mississippi_records.R
@@ -2,7 +2,7 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 mississippi_records_pull <- function(x){
-    readxl::read_excel("results/manual/COVID-19 DAILY REPORT VitalCore 090321.xlsx")
+    readxl::read_excel("/tmp/sel_dl/COVID-19 DAILY REPORT VitalCore 090321.xlsx")
 }
 
 mississippi_records_restruct <- function(x){


### PR DESCRIPTION
1. Adds `historical_mississippi_records_scraper` for data from the Mississippi DOC for cases, deaths, vaccines. 
2. Adds `historical_tx_vaccine_records_scraper` for vaccine data from TDCJ. Also gives us updated population values for staff and incarcerated people! 
3. Makes the manual Mississippi scraper defunct (since we want the facility-level data), and I renamed the manual Google Sheet so we don't accidentally pull from it. 

Note – I set these up as historical scrapers so that we can assign the date to not today. We also don't want them to run in the main set since we only want to run them when we get updated records. 