### PR TITLE
Fix North dakota scraper

### DIFF
--- a/production/scrapers/north_dakota.R
+++ b/production/scrapers/north_dakota.R
@@ -8,7 +8,7 @@ north_dakota_check_date <- function(url, date = Sys.Date()){
         rvest::html_text()
     
     date_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_extract("\\d{1,2}-\\d{1,2}-\\d{2,4}") %>%
         lubridate::mdy() %>%
         error_on_date(expected_date = date)

--- a/production/scrapers/north_dakota.R
+++ b/production/scrapers/north_dakota.R
@@ -24,9 +24,12 @@ north_dakota_pull <- function(url){
     del_ <- capture.output(remDr$open())
     remDr$navigate(url)
     
-    remDr$getPageSource() %>%
+    raw_html <- remDr$getPageSource() %>%
         {xml2::read_html(.[[1]])}
     
+    remDr$quit()
+
+    return(raw_html)
 }
 
 north_dakota_restruct <- function(scraped_html){
@@ -48,12 +51,12 @@ north_dakota_restruct <- function(scraped_html){
             rvest::html_text() %>%
             str_replace_all(" ", ".") %>%
             {str_c(group_, ., sep = ".")}
-    
+
         fac <- sub_svg %>%
             rvest::html_node(".highcharts-xaxis-labels") %>%
             rvest::html_nodes("text") %>%
             rvest::html_text()
-    
+
         data_labels <- sub_svg %>%
             rvest::html_nodes(".highcharts-data-labels")
     


### PR DESCRIPTION
Notable changes:
* Quit remDr to avoid memory leak, speed scrape. Technically, this is one where we _could_ take out selenium I think. I tried to do that, but selenium read the HTML in a different way that would have required a big rewriting of `north_dakota_restruct`. Since it was proving to be time-intensive, I decided to let selenium be.
* Change check date to look for 20xx
* Variable names again