### PR TITLE
Pa bi scrapers

### DIFF
--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -12,7 +12,6 @@ pennsylvania_bi_cases_pull <- function(url, wait = 7){
     )
     
     del_ <- capture.output(remDr$open())
-    
     remDr$navigate(cases_page)
     
     Sys.sleep(wait)

--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -1,13 +1,9 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-pennsylvania_bi_cases_pull <- function(x, wait = 10){
+pennsylvania_bi_cases_pull <- function(url, wait = 7){
     # scrape from the power bi iframe directly
-    y <- "https://app.powerbigov.us/view?r=" %>%
-        str_c(
-            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
-            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9&",
-            "pageName=ReportSection331d709ad3ad8215c6c6")
+    cases_page <- str_c(url,"&pageName=ReportSection331d709ad3ad8215c6c6")
     
     remDr <- RSelenium::remoteDriver(
         remoteServerAddr = "localhost",
@@ -16,11 +12,14 @@ pennsylvania_bi_cases_pull <- function(x, wait = 10){
     )
     
     del_ <- capture.output(remDr$open())
-    remDr$navigate(y)
+    
+    remDr$navigate(cases_page)
     
     Sys.sleep(wait)
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+
+    remDr$quit()
     
     is_covid_cases <- raw_html %>%
         rvest::html_node("h3.preTextWithEllipsis") %>%
@@ -35,9 +34,9 @@ pennsylvania_bi_cases_pull <- function(x, wait = 10){
     raw_html
 }
 
-pennsylvania_bi_cases_restruct  <- function(x){
+pennsylvania_bi_cases_restruct  <- function(raw_html){
     
-    windows <- x %>%
+    windows <- raw_html %>%
         rvest::html_nodes(xpath="//transform[@class='bringToFront']")
     
     df_list <- bind_rows(lapply(1:length(windows), function(i){
@@ -87,8 +86,8 @@ pennsylvania_bi_cases_restruct  <- function(x){
     
 }
 
-pennsylvania_bi_cases_extract <- function(x){
-    x %>%
+pennsylvania_bi_cases_extract <- function(restructured_data){
+    restructured_data %>%
         clean_scraped_df() %>%
         # i think we can assume not being present in the active table means zero
         mutate(Residents.Active = ifelse(
@@ -116,7 +115,11 @@ pennsylvania_bi_cases_scraper <- R6Class(
         log = NULL,
         initialize = function(
             log,
-            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            # The landing page for the BI report is https://www.cor.pa.gov/Pages/COVID-19.aspx
+            url = str_c(
+                "https://app.powerbigov.us/view?r=",
+                "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+                "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9"),
             id = "pennsylvania_bi_cases",
             type = "html",
             state = "PA",

--- a/production/scrapers/pennsylvania_bi_deaths.R
+++ b/production/scrapers/pennsylvania_bi_deaths.R
@@ -1,13 +1,9 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-pennsylvania_bi_deaths_pull <- function(x, wait = 10){
+pennsylvania_bi_deaths_pull <- function(url, wait = 7){
     # scrape from the power bi iframe directly
-    y <- "https://app.powerbigov.us/view?r=" %>%
-        str_c(
-            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
-            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9",
-            "&pageName=ReportSectionc6adf1f0d7011b2ed62c")
+    deaths_page <- str_c(url,"&pageName=ReportSectionc6adf1f0d7011b2ed62c")
     
     remDr <- RSelenium::remoteDriver(
         remoteServerAddr = "localhost",
@@ -16,11 +12,13 @@ pennsylvania_bi_deaths_pull <- function(x, wait = 10){
     )
     
     del_ <- capture.output(remDr$open())
-    remDr$navigate(y)
+    remDr$navigate(deaths_page)
     
     Sys.sleep(wait)
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    remDr$quit()
     
     is_covid_deaths <- raw_html %>%
         rvest::html_nodes(xpath="//h3[@class='preTextWithEllipsis']") %>%
@@ -35,16 +33,16 @@ pennsylvania_bi_deaths_pull <- function(x, wait = 10){
     raw_html
 }
 
-pennsylvania_bi_deaths_restruct  <- function(x){
+pennsylvania_bi_deaths_restruct  <- function(raw_html){
     val_sr_str <- "//text[@class='label' and contains(@transform,'translate')]"
     lab_sr_str <- "//text[@class='setFocusRing']//title"
 
     tibble(
-        Name = x %>%
+        Name = raw_html %>%
             rvest::html_nodes(xpath=lab_sr_str) %>%
             rvest::html_text(),
         
-        Residents.Deaths = x %>%
+        Residents.Deaths = raw_html %>%
             rvest::html_nodes(xpath=val_sr_str) %>%
             rvest::html_text())
 }
@@ -52,8 +50,8 @@ pennsylvania_bi_deaths_restruct  <- function(x){
 
 
 
-pennsylvania_bi_deaths_extract <- function(x){
-    x %>%
+pennsylvania_bi_deaths_extract <- function(restructured_data){
+    restructured_data %>%
         clean_scraped_df()
 }
 
@@ -76,7 +74,11 @@ pennsylvania_bi_deaths_scraper <- R6Class(
         log = NULL,
         initialize = function(
             log,
-            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            # The landing page for the BI report is https://www.cor.pa.gov/Pages/COVID-19.aspx
+            url = str_c(
+                "https://app.powerbigov.us/view?r=",
+                "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+                "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9"),
             id = "pennsylvania_bi_deaths",
             type = "html",
             state = "PA",

--- a/production/scrapers/pennsylvania_bi_testing.R
+++ b/production/scrapers/pennsylvania_bi_testing.R
@@ -1,13 +1,9 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-pennsylvania_bi_testing_pull <- function(x, wait = 10){
+pennsylvania_bi_testing_pull <- function(url, wait = 10){
     # scrape from the power bi iframe directly
-    y <- "https://app.powerbigov.us/view?r=" %>%
-        str_c(
-            "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
-            "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9&",
-            "pageName=ReportSection2804d81ebd8989abad15")
+    testing_page <- str_c(url,"&pageName=ReportSection2804d81ebd8989abad15")
     
     remDr <- RSelenium::remoteDriver(
         remoteServerAddr = "localhost", 
@@ -16,11 +12,13 @@ pennsylvania_bi_testing_pull <- function(x, wait = 10){
     )
     
     del_ <- capture.output(remDr$open())
-    remDr$navigate(y)
+    remDr$navigate(testing_page)
     
     Sys.sleep(wait)
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
+    
+    remDr$quit()
     
     is_covid_testing <- raw_html %>%
         rvest::html_nodes("h3.preTextWithEllipsis") %>%
@@ -35,14 +33,14 @@ pennsylvania_bi_testing_pull <- function(x, wait = 10){
     raw_html
 }
 
-pennsylvania_bi_testing_restruct  <- function(x){
+pennsylvania_bi_testing_restruct  <- function(raw_html){
   
-    labs <- x %>%
+    labs <- raw_html %>%
         rvest::html_nodes("text.setFocusRing") %>%
         sapply(function(z){
             rvest::html_text(rvest::html_node(z, "title"))})
     
-    windows <- x %>%
+    windows <- raw_html %>%
         rvest::html_nodes(".labelGraphicsContext")
     
     
@@ -66,8 +64,8 @@ pennsylvania_bi_testing_restruct  <- function(x){
     )    
 }
 
-pennsylvania_bi_testing_extract <- function(x){
-    x %>%
+pennsylvania_bi_testing_extract <- function(restructured_data){
+    restructured_data %>%
         clean_scraped_df()
 }
 
@@ -91,7 +89,11 @@ pennsylvania_bi_testing_scraper <- R6Class(
         log = NULL,
         initialize = function(
             log,
-            url = "https://www.cor.pa.gov/Pages/COVID-19.aspx",
+            # The landing page for the BI report is https://www.cor.pa.gov/Pages/COVID-19.aspx
+            url = str_c(
+                "https://app.powerbigov.us/view?r=",
+                "eyJrIjoiMTcyY2I2MjMtZjJjNC00NjNjLWJjNWYtNTZlZWE1YmRkYWYwIiwidCI",
+                "6IjQxOGUyODQxLTAxMjgtNGRkNS05YjZjLTQ3ZmM1YTlhMWJkZSJ9"),
             id = "pennsylvania_bi_testing",
             type = "html",
             state = "PA",

--- a/production/scrapers/pennsylvania_bi_testing.R
+++ b/production/scrapers/pennsylvania_bi_testing.R
@@ -1,7 +1,7 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-pennsylvania_bi_testing_pull <- function(url, wait = 10){
+pennsylvania_bi_testing_pull <- function(url, wait = 7){
     # scrape from the power bi iframe directly
     testing_page <- str_c(url,"&pageName=ReportSection2804d81ebd8989abad15")
     

--- a/production/scrapers/pennsylvania_bi_vaccination.R
+++ b/production/scrapers/pennsylvania_bi_vaccination.R
@@ -1,7 +1,7 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-pennsylvania_bi_vaccination_pull <- function(x, wait = 10){
+pennsylvania_bi_vaccination_pull <- function(url, wait = 10){
     # scrape from the power bi iframe directly
     y <- "https://app.powerbigov.us/view?r=" %>%
         str_c(


### PR DESCRIPTION
This PR changes pennsylvania_bi_cases.R, pennsylvania_bi_deaths.R, pennsylvania_bi_population, pennsylvania_bi_staff_cases.R and pennsylvania_bi_testing.R. For each scraper, the following notable changes were introduced:
* `remDr$quit()` to speed scrapers
* the URL attribute was changed to the powerBi report where we pull the data. The landing page that holds that report is still preserved in each. Changing the URL attribute in each means we no longer have unused function arguments in our `_pull` functions
* reduce default wait to 7 seconds. I only needed 5 on my machine, but I wanted to preserve some buffer. 
* descriptive variable names