### PR TITLE
Vax rates vars added to latest-state-data output 

### DIFF
--- a/R/generic_scraper.R
+++ b/R/generic_scraper.R
@@ -15,7 +15,9 @@ UCLABB_MAIN_VARIABLES <- c(
     "Residents.Population", "Residents.Active",
     "Staff.Vadmin", "Residents.Vadmin",
     "Staff.Initiated", "Residents.Initiated",
+    "Staff.Initiated.Pct", "Residents.Initiated.Pct", 
     "Staff.Completed", "Residents.Completed", 
+    "Residents.Completed.Pct",
     "Staff.Population", "Staff.Active"
 )
 

--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -109,7 +109,6 @@ get_california_vaccine_bi_percentages <- function(x){
         .[1] %>% 
         rvest::html_node(".innerContainer")
     x %>% 
-        # rvest::html_node(xpath="//*[@id='pvExplorationHost']/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[11]/transform/div/div[3]/div/visual-modern/div/svg/g[2]/text") %>%
         rvest::html_nodes(".mainText") %>%
         rvest::html_text()
     

--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -103,6 +103,20 @@ get_california_vaccine_bi_table <- function(x, idx){
     dat_df
 }
 
+get_california_vaccine_bi_percentages <- function(x){
+    tab <- x %>%
+        rvest::html_nodes(".tableEx") %>%
+        .[1] %>% 
+        rvest::html_node(".innerContainer")
+    x %>% 
+        # rvest::html_node(xpath="//*[@id='pvExplorationHost']/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[11]/transform/div/div[3]/div/visual-modern/div/svg/g[2]/text") %>%
+        rvest::html_nodes(".mainText") %>%
+        rvest::html_text()
+    
+        
+        
+}
+
 california_vaccine_bi_restruct <- function(x){
     sub_files <- x %>%
         rvest::html_nodes("iframe") %>%
@@ -155,7 +169,23 @@ california_vaccine_bi_restruct <- function(x){
             "longer work. Please inspect.")
     }
     
-    as_tibble(full_join(vac_list[[1]], vac_list[[2]], by = "Name"))
+    fac_tab <- as_tibble(full_join(vac_list[[1]], vac_list[[2]], by = "Name"))
+    
+    ## get statewide percentages
+    statewide_pct <- lhtml %>% 
+        .[[1]] %>%
+        rvest::html_nodes(".mainText") 
+    res_part_pct <- statewide_pct %>% .[1] %>% rvest::html_text() %>% string_to_clean_numeric()
+    res_full_pct <- statewide_pct %>% .[2] %>% rvest::html_text() %>% string_to_clean_numeric()
+    staff_part_pct <- statewide_pct %>% .[3] %>% rvest::html_text() %>% string_to_clean_numeric()
+    staff_full_pct <- statewide_pct %>% .[4] %>% rvest::html_text() %>% string_to_clean_numeric()
+    statewide_pct <- tibble(Name = "STATEWIDE",
+                            Residents.Initiated.Pct = (res_part_pct + res_full_pct)/100,
+                            Staff.Initiated.Pct = (staff_part_pct + staff_full_pct)/100)
+    out <- fac_tab %>%
+        bind_rows(statewide_pct)
+    return(out)
+
 }
 
 

--- a/production/scrapers/delaware.R
+++ b/production/scrapers/delaware.R
@@ -3,7 +3,7 @@ source("./R/utilities.R")
 
 delaware_check_date <- function(x, date = Sys.Date()){
     "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
-        googlesheets4::read_sheet(sheet = "DE", col_types = "Dccccccccccc") %>%
+        googlesheets4::read_sheet(sheet = "DE", col_types = "Dcccccccccccc") %>%
         pull(Date) %>%
         max(na.rm=TRUE) %>%
         error_on_date(date)
@@ -12,17 +12,16 @@ delaware_check_date <- function(x, date = Sys.Date()){
 delaware_pull <- function(x){
     "1VhAAbzipvheVRG0UWKMLT6mCVQRMdV98lUUkk-PCYtQ" %>%
         googlesheets4::read_sheet(sheet = "DE", 
-                                  col_types = "Dccccccccccc")
+                                  col_types = "Dcccccccccccc")
 }
 
 delaware_restruct <- function(x){
     x %>%
         filter(!is.na(Date)) %>% 
-        filter(Date == max(Date))
+        filter(Date == max(Date)) 
 }
 
 delaware_extract <- function(x){
-    
     x %>% 
         filter(!is.na(Name)) %>% 
         select(
@@ -30,8 +29,10 @@ delaware_extract <- function(x){
             Residents.Tadmin, Residents.Deaths, 
             Staff.Active, Residents.Active, 
             Staff.Recovered, Residents.Recovered, 
-            Residents.Initiated, Residents.Completed) %>% 
-        clean_scraped_df()
+            Residents.Initiated, Residents.Initiated.Pct,
+            Residents.Completed) %>% 
+        mutate(Residents.Initiated.Pct = (as.numeric(Residents.Initiated.Pct)/100)) %>%
+        clean_scraped_df() 
 }
 
 #' Scraper class for general delaware COVID data

--- a/production/scrapers/delaware.R
+++ b/production/scrapers/delaware.R
@@ -18,7 +18,7 @@ delaware_pull <- function(x){
 delaware_restruct <- function(x){
     x %>%
         filter(!is.na(Date)) %>% 
-        filter(Date == max(Date)) 
+        filter(Date == max(Date))
 }
 
 delaware_extract <- function(x){

--- a/production/scrapers/maine.R
+++ b/production/scrapers/maine.R
@@ -63,7 +63,7 @@ maine_extract <- function(x){
         as_tibble() %>% 
         filter(Name != "",
                Name != "All Facilities - Resident") %>%
-        mutate(Perc.Fully.Vax.Cln = as.numeric(gsub("[\\%,]", "", Perc.Fully.Vax)) / 100) %>%
+        mutate(Residents.Completed.Pct = as.numeric(gsub("[\\%,]", "", Perc.Fully.Vax)) / 100) %>%
         select(-Perc.Fully.Vax)
     
     # Tests and cases 
@@ -83,17 +83,18 @@ maine_extract <- function(x){
     
     check_names_extractable(tests_, col_name_df)
     
-    rename_extractable(tests_, col_name_df) %>%
+    out <- rename_extractable(tests_, col_name_df) %>%
         as_tibble() %>%
         {suppressWarnings(mutate_at(., vars(starts_with("Res")), as.numeric))} %>%
         filter(!(Name == "" | is.na(Residents.Tadmin))) %>%
         filter(!str_detect(Name, "(?i)total")) %>% 
         full_join(pop_df, by = "Name") %>% 
         full_join(vaccines_df, by = "Name") %>% 
-        mutate(Residents.Completed = round(Residents.Population * Perc.Fully.Vax.Cln)) %>%
-        select(-ends_with("Drop"),
-               -Perc.Fully.Vax.Cln) %>% 
+        mutate(Residents.Completed = round(Residents.Population * Residents.Completed.Pct)) %>%
+        select(-ends_with("Drop")) %>% 
         clean_scraped_df()
+    
+    return(out)
 }
 
 #' Scraper class for general maine COVID data

--- a/production/scrapers/wisconsin_vaccine.R
+++ b/production/scrapers/wisconsin_vaccine.R
@@ -68,6 +68,8 @@ wisconsin_vaccine_extract <- function(x){
     x %>% 
         select(Residents.Initiated = number_partially_or_fully_vaccinated, 
                Residents.Completed = number_fully_vaccinated, 
+               Residents.Initiated.Pct = percent_partially_or_fully_vaccinated,
+               Residents.Completed.Pct = percent_fully_vaccinated,
                Name = facility) %>% 
         filter(!str_detect(Name, "(?i)total")) %>% 
         clean_scraped_df()


### PR DESCRIPTION
Changes necessary for https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/336

The overarching goal for this change is to have the website reflect the most up-to-date state-wide vaccine percentages, and this change only effects **[latest-state-counts.csv](https://github.com/uclalawcovid19behindbars/data/blob/master/latest-data/latest_state_counts.csv)**.

One note: I decided to coalesce the vaccine rate variables with our calculated rates in `write_state_agg_data` rather than a function in `behindbarstools`. I did that because it felt much simpler to do this than to make the change within `calc_aggregate_counts`. 


If we want to add this variable to historical state data and/or facility-level data, we should create an additional issue to tackle in the future. 