### PR TITLE
Date fixes

### DIFF
--- a/production/scrapers/arizona.R
+++ b/production/scrapers/arizona.R
@@ -9,7 +9,7 @@ arizona_check_date <- function(url, date = Sys.Date()){
         rvest::html_node(".field-content") %>% 
         rvest::html_text() %>%
         lubridate::mdy()
-
+    
     error_on_date(site_date, date)
 }
 

--- a/production/scrapers/arizona.R
+++ b/production/scrapers/arizona.R
@@ -1,14 +1,15 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-arizona_check_date <- function(x, date = Sys.Date()){
-    base_page <- xml2::read_html(x)
+arizona_check_date <- function(url, date = Sys.Date()){
+    base_page <- xml2::read_html(url)
     
     site_date <- base_page %>%
-        rvest::html_nodes(xpath = "//*[@id='block-views-covid-19-data-table-block-5']/div/div/div/div/span[2]") %>%
+        rvest::html_nodes(".views-field-changed") %>%
+        rvest::html_node(".field-content") %>% 
         rvest::html_text() %>%
         lubridate::mdy()
-    
+
     error_on_date(site_date, date)
 }
 

--- a/production/scrapers/defunct/new_jersey.R
+++ b/production/scrapers/defunct/new_jersey.R
@@ -1,14 +1,14 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-new_jersey_check_date <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+new_jersey_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     date_txt <- rvest::html_nodes(base_html, 
                                   xpath="/html/body/div[3]/div[4]/div[1]/div/div[2]/p[1]") %>%
         rvest::html_text()
     
     date_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_extract("\\d{1,2}/\\d{1,2}/\\d{2,4}") %>%
         lubridate::mdy() %>%
         error_on_date(expected_date = date)

--- a/production/scrapers/hawaii.R
+++ b/production/scrapers/hawaii.R
@@ -1,18 +1,18 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-hawaii_date_check <- function(x, date = Sys.Date()){
+hawaii_date_check <- function(url, date = Sys.Date()){
     img <- get_src_by_attr(
-        x, "img", attr = "src", attr_regex = "(?i)Inmate-Test-Report") %>%
+        url, "img", attr = "src", attr_regex = "(?i)Inmate-Test-Report") %>%
         {gsub("-[0-9]+x[0-9]+", "", .)} %>%
         magick::image_read()
     
     img %>%
-        magick::image_crop("700x100+300+200") %>%
+        magick::image_crop("700x100+400+200") %>%
         magick::image_ocr() %>%
         str_split("Updated|[:space:]") %>%
         unlist() %>%
-        {.[str_detect(., "21")]} %>%
+        {.[str_detect(., "20")]} %>%
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/hawaii_staff.R
+++ b/production/scrapers/hawaii_staff.R
@@ -8,12 +8,11 @@ hawaii_staff_date_check <- function(x, date = Sys.Date()){
         magick::image_read() 
     
     img %>% 
-        magick::image_crop("500x200") %>% 
+        magick::image_crop("200x90") %>% 
         magick::image_ocr() %>% 
-        str_split("Updated") %>% 
+        str_split("\n") %>% 
         unlist() %>%
-        {.[str_detect(., "(?i)21")]} %>%
-        str_squish() %>% 
+        {.[str_detect(., "\\d")]} %>%
         str_extract("\\d{1,2}/\\d{1,2}/\\d{1,2}") %>%
         lubridate::mdy() %>%
         error_on_date(date)

--- a/production/scrapers/illinois_youth.R
+++ b/production/scrapers/illinois_youth.R
@@ -1,14 +1,14 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-illinois_youth_date_check <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+illinois_youth_date_check <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     
     base_html %>%
         rvest::html_nodes("p") %>%
         rvest::html_text() %>% 
         {.[str_detect(., "(?i)as of")]} %>% 
-        {.[str_detect(., "21")]} %>% 
+        {.[str_detect(., "22")]} %>% 
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/indiana.R
+++ b/production/scrapers/indiana.R
@@ -1,16 +1,16 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-indiana_date_check <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+indiana_date_check <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     
     base_html %>%
         rvest::html_nodes("p") %>%
         rvest::html_text() %>% 
-        {.[str_detect(., "(?i)last updated")]} %>% 
+        {.[str_detect(., "(?i)current as of")]} %>% 
         str_split("updated") %>% 
         unlist() %>% 
-        {.[str_detect(., "21")]} %>% 
+        {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/indiana.R
+++ b/production/scrapers/indiana.R
@@ -8,9 +8,7 @@ indiana_date_check <- function(url, date = Sys.Date()){
         rvest::html_nodes("p") %>%
         rvest::html_text() %>% 
         {.[str_detect(., "(?i)current as of")]} %>% 
-        str_split("updated") %>% 
         unlist() %>% 
-        {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/kentucky.R
+++ b/production/scrapers/kentucky.R
@@ -10,7 +10,7 @@ kentucky_date_check <- function(x, date = Sys.Date()){
         {.[str_detect(., "(?i)as of")]} %>% 
         str_split("as of") %>% 
         unlist() %>% 
-        {.[str_detect(., "\\d{1,2}-\\d{1,2}-\\d{1,2}")]} %>% 
+        .[[2]] %>%
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/kentucky.R
+++ b/production/scrapers/kentucky.R
@@ -10,7 +10,7 @@ kentucky_date_check <- function(x, date = Sys.Date()){
         {.[str_detect(., "(?i)as of")]} %>% 
         str_split("as of") %>% 
         unlist() %>% 
-        {.[str_detect(., "21")]}%>% 
+        {.[str_detect(., "\\d{1,2}-\\d{1,2}-\\d{1,2}")]} %>% 
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/maryland_youth.R
+++ b/production/scrapers/maryland_youth.R
@@ -10,7 +10,7 @@ maryland_youth_date_check <- function(x, date = Sys.Date()){
         magick::image_ocr() %>% 
         str_split("(?i)date") %>% 
         unlist() %>%
-        {.[str_detect(., "21")]} %>% 
+        {.[str_detect(., "20")]} %>% # look for year 20xx 
         lubridate::mdy() %>% 
         error_on_date(date)
 }

--- a/production/scrapers/michigan_vaccine.R
+++ b/production/scrapers/michigan_vaccine.R
@@ -9,8 +9,9 @@ michigan_vaccine_date_check <- function(x, date = Sys.Date()){
         rvest::html_text() %>% 
         {.[str_detect(., "(?i)correction")]} %>% 
         stringr::str_split("(?i)through") %>% 
-        unlist() %>% 
-        {.[str_detect(., "21")]} %>% 
+        unlist() %>%
+        # look for date in format mm/dd/yy
+        {.[str_detect(., "\\d{1,2}/\\d{1,2}/\\d{1,2}")]} %>% 
         lubridate::mdy() %>% 
         error_on_date(date)
 }

--- a/production/scrapers/michigan_vaccine.R
+++ b/production/scrapers/michigan_vaccine.R
@@ -8,10 +8,6 @@ michigan_vaccine_date_check <- function(x, date = Sys.Date()){
         rvest::html_nodes("caption") %>% 
         rvest::html_text() %>% 
         {.[str_detect(., "(?i)correction")]} %>% 
-        stringr::str_split("(?i)through") %>% 
-        unlist() %>%
-        # look for date in format mm/dd/yy
-        {.[str_detect(., "\\d{1,2}/\\d{1,2}/\\d{1,2}")]} %>% 
         lubridate::mdy() %>% 
         error_on_date(date)
 }

--- a/production/scrapers/montana.R
+++ b/production/scrapers/montana.R
@@ -14,6 +14,8 @@ montana_check_date <- function(url, date = Sys.Date()){
 
     date_check <- lubridate::mdy(date_check_txt) %>%
         error_on_date(expected_date = date)
+    
+    return(date_check)
 }
 
 montana_pull <- function(x){

--- a/production/scrapers/montana.R
+++ b/production/scrapers/montana.R
@@ -1,22 +1,18 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-montana_check_date <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
-    date_check_txt <- rvest::html_nodes(base_html, xpath = "//*[@id=\"content-wrapper\"]/main/div/div[2]/div/p[4]/em/text()") %>%
-        rvest::html_text()
-
-    date_check_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
-        str_split("Data last updated at") %>%
-        unlist() %>%
-        .[2] %>%
+montana_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
+    date_check_txt <- rvest::html_nodes(base_html, css = 'em') %>%
+        rvest::html_text() %>% 
         str_split("on") %>%
         unlist() %>%
         .[2] %>%
-        str_remove("\\.") %>%
-        str_replace("Sept", "Sep") %>% 
-        lubridate::mdy() %>%
+        str_replace("Sept", "Sep")
+           
+    date_check_txt <- gsub("[[:punct:]]", "", date_check_txt)
+
+    date_check <- lubridate::mdy(date_check_txt) %>%
         error_on_date(expected_date = date)
 }
 

--- a/production/scrapers/new_jersey_statewide.R
+++ b/production/scrapers/new_jersey_statewide.R
@@ -1,21 +1,20 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-new_jersey_statewide_check_date <- function(x, date = Sys.Date()){
-    png <- get_src_by_attr(x, "img", attr = "src", attr_regex = "COVID_Chart") %>%
+new_jersey_statewide_check_date <- function(url, date = Sys.Date()){
+    png <- get_src_by_attr(url, "img", attr = "src", attr_regex = "COVID_Chart") %>%
         last()
-    
+
     png %>%
         magick::image_read() %>%
-        magick::image_crop("1200x800+0+400") %>%
+        magick::image_crop("1400x800+0+657") %>%
         magick::image_ocr() %>%
-        {.[str_detect(., "(?i)20")]} %>%
-        str_split(., "(?i)updated as of |\nPercent") %>%
+        str_split(., "(?i)updated as of") %>%
         unlist() %>%
         .[2] %>%
-        str_split(., "(?i)and include week") %>% 
-        .[[1]] %>% 
-        {.[str_detect(., "(?i)2021")]} %>% 
+        str_split(., "(?i). Between") %>%
+        unlist() %>%
+        .[1] %>%
         lubridate::mdy() %>% 
         error_on_date(date)
 }

--- a/production/scrapers/new_york.R
+++ b/production/scrapers/new_york.R
@@ -1,19 +1,18 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-new_york_check_date <- function(x, date = Sys.Date()){
-  pdf <- get_src_by_attr(x, "a", attr = "href", attr_regex = "(?i)facility-")
-  
-  pdf %>% 
-    magick::image_read_pdf(pages = 1) %>% 
-    magick::image_crop("1500x400+200") %>% 
-    magick::image_ocr() %>% 
-    {.[str_detect(., "(?i)21")]} %>%
-    str_split(., "(?i)as of | at") %>%
-    unlist() %>%
-    .[2] %>% 
-    lubridate::mdy() %>% 
-    error_on_date(date)
+new_york_check_date <- function(url, date = Sys.Date()){
+    pdf <- get_src_by_attr(url, "a", attr = "href", attr_regex = "(?i)facility-")
+    
+    pdf %>% 
+        magick::image_read_pdf(pages = 1) %>% 
+        magick::image_crop("1500x300+200") %>% 
+        magick::image_ocr() %>% 
+        str_split(., "(?i)as of | at") %>%
+        unlist() %>%
+        .[2] %>% 
+        lubridate::mdy() %>% 
+        error_on_date(date)
 }
 
 new_york_pull <- function(x){

--- a/production/scrapers/north_carolina.R
+++ b/production/scrapers/north_carolina.R
@@ -1,13 +1,13 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-north_carolina_check_date <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+north_carolina_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     date_txt <- rvest::html_nodes(base_html, ".asOfText") %>%
         rvest::html_text()
     
     date_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_extract("\\d{1,2}/\\d{1,2}/\\d{2,4}") %>%
         lubridate::mdy() %>%
         error_on_date(expected_date = date)

--- a/production/scrapers/north_carolina_youth.R
+++ b/production/scrapers/north_carolina_youth.R
@@ -2,14 +2,14 @@ source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
 
-north_carolina_youth_check_date <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+north_carolina_youth_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     date_txt <- rvest::html_nodes(base_html, 
                                   xpath="//*[@id=\"node-13727\"]/div/div/div/div/div[2]/section/section/div[2]/div/div/div/p[1]") %>%
         rvest::html_text()
     
     date_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         lubridate::mdy() %>%
         error_on_date(expected_date = date)
 }

--- a/production/scrapers/north_dakota_population.R
+++ b/production/scrapers/north_dakota_population.R
@@ -1,14 +1,14 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-nd_pop_check_date <- function(x, date = Sys.Date()){
-    img <- magick::image_read_pdf(x, pages = 1) 
+nd_pop_check_date <- function(url, date = Sys.Date()){
+    img <- magick::image_read_pdf(url, pages = 1) 
     
     date_box <- magick::image_crop(img, "500x240+2000+160") %>% 
         magick::image_ocr() 
     
     date_box %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_extract("\\d{1,2}/\\d{1,2}/\\d{2,4}") %>%
         lubridate::mdy() %>%
         error_on_date(expected_date = date)

--- a/production/scrapers/nyc_jails.R
+++ b/production/scrapers/nyc_jails.R
@@ -1,13 +1,8 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-nyc_jails_check_date <- function(x, date = Sys.Date()){
-    html_page <- xml2::read_html(x)
-    
-    pdf_page <- html_page %>%
-        rvest::html_nodes("a") %>%
-        .[str_squish(rvest::html_text(.)) == "CHS COVID-19 Data Snapshot"] %>%
-        rvest::html_attr("href") %>%
+nyc_jails_check_date <- function(url, date = Sys.Date()){
+    pdf_page <- nyc_jails_pull(url) %>% 
         magick::image_read_pdf(pages = 1)
     
     date_box <- magick::image_crop(pdf_page, "1550x485+0+0") %>% 
@@ -17,17 +12,41 @@ nyc_jails_check_date <- function(x, date = Sys.Date()){
         {.[str_detect(., "(?i)21")]} %>%
         str_extract("\\d{1,2}/\\d{1,2}/\\d{2,4}") %>%
         lubridate::mdy() %>%
-        error_on_date(expected_date = date)
+        error_on_date(date)
 }
 
 
-nyc_jails_pull <- function(x){
-    html_page <- xml2::read_html(x)
+nyc_jails_pull <- function(url){
+    html_page <- xml2::read_html(url)
     
-    html_page %>%
+    pdf_address <- html_page %>%
         rvest::html_nodes("a") %>%
         .[str_squish(rvest::html_text(.)) == "CHS COVID-19 Data Snapshot"] %>%
         rvest::html_attr("href")
+       
+    tryCatch(
+        {
+            magick::image_read_pdf(pdf_address, pages = 1)
+            # if image_read_pdf is successful, return pdf_address
+            pdf_address
+        },
+        error=function(error) {
+            if(str_detect(error$message, "HTTP 404")){
+                pdf_address <- .change_address_one_day_earlier(pdf_address)
+            }
+        }
+    )
+}
+
+.change_address_one_day_earlier <- function(address){
+    new_date <- str_extract(address, "\\d{5,}") %>%
+        strtoi() %>%
+        sum(-1) %>%
+        as.character()
+    
+    address_split_on_date <- str_split(address, "\\d{5,}") %>% unlist()
+    
+    str_c(address_split_on_date[1], new_date, address_split_on_date[2])
 }
 
 nyc_jails_restruct <- function(x){

--- a/production/scrapers/ohio.R
+++ b/production/scrapers/ohio.R
@@ -1,15 +1,15 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-ohio_check_date <- function(x, date = Sys.Date()){
-    src <-  get_src_by_attr(x, "a", attr = "href", attr_regex = "(?i)covid")
+ohio_check_date <- function(url, date = Sys.Date()){
+    src <-  get_src_by_attr(url, "a", attr = "href", attr_regex = "(?i)covid")
     img <- magick::image_read_pdf(src, pages = 1) 
     
     date_box <- magick::image_crop(img, "500x240+1000+160") %>% 
-        magick::image_ocr() 
+        magick::image_ocr()
     
     date_box %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_extract("\\d{1,2}/\\d{1,2}/\\d{2,4}") %>%
         lubridate::mdy() %>%
         error_on_date(expected_date = date)

--- a/production/scrapers/orange_county.R
+++ b/production/scrapers/orange_county.R
@@ -1,13 +1,13 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-orange_county_check_date <- function(x, date = Sys.Date()){
-    base_html <- xml2::read_html(x)
+orange_county_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     date_txt <- rvest::html_nodes(base_html, xpath = "//*[@id=\"block-countyoc-content\"]/article/div/div/div/div/h3[1]") %>%
         rvest::html_text()
     
     date_txt %>%
-        {.[str_detect(., "(?i)21")]} %>%
+        {.[str_detect(., "(?i)20")]} %>% # look for year 20xx
         str_split(., "(?i)Updated ") %>%
         unlist() %>%
         .[2] %>%

--- a/production/scrapers/san_diego_jails.R
+++ b/production/scrapers/san_diego_jails.R
@@ -5,12 +5,12 @@ san_diego_jails_check_date <- function(x, date = Sys.Date()){
     html_obj <- xml2::read_html(x)
 
     html_obj %>%
-        rvest::html_nodes("a") %>%
+        rvest::html_nodes("ul") %>%
         .[str_detect(rvest::html_text(.), "(?i)jail daily figures")] %>%
         rvest::html_text() %>%
-        str_split("(?i)as of") %>%
+        str_split("(?i)covid-19 jail daily figures as of |\n") %>%
         unlist() %>%
-        last() %>%
+        .[2] %>%
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/san_diego_jails_employee.R
+++ b/production/scrapers/san_diego_jails_employee.R
@@ -5,7 +5,7 @@ san_diego_jails_employee_check_date <- function(x, date = Sys.Date()){
     html_obj <- xml2::read_html(x)
     
     html_obj %>%
-        rvest::html_nodes("a") %>%
+        rvest::html_nodes("ul") %>%
         .[str_detect(rvest::html_text(.), "(?i)employee status")] %>%
         rvest::html_text() %>%
         str_split("(?i)as of") %>%

--- a/production/scrapers/south_dakota.R
+++ b/production/scrapers/south_dakota.R
@@ -1,10 +1,10 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-south_dakota_check_date <- function(x, date = Sys.Date()){
-    get_src_by_attr(x, "a", attr = "href", attr_regex = "(?i)case") %>%
+south_dakota_check_date <- function(url, date = Sys.Date()){
+    get_src_by_attr(url, "a", attr = "href", attr_regex = "(?i)case") %>%
         magick::image_read_pdf() %>%
-        magick::image_crop("800x45+2700+320") %>%
+        magick::image_crop("800x50+2700+320") %>%
         magick::image_ocr() %>%
         str_split(" ") %>%
         unlist() %>%

--- a/production/scrapers/utah_statewide.R
+++ b/production/scrapers/utah_statewide.R
@@ -1,17 +1,17 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-utah_statewide_check_date <- function(x, date = Sys.Date()){
-    z <- xml2::read_html(x)
+utah_statewide_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
     
-    z %>%
+    base_html %>%
         rvest::html_nodes("p") %>% 
         rvest::html_text() %>% 
         {.[str_detect(., "(?i)updated")]} %>% 
         first() %>% 
         str_split("updated") %>% 
         unlist() %>% 
-        {.[str_detect(., "21")]} %>% 
+        {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/utah_statewide.R
+++ b/production/scrapers/utah_statewide.R
@@ -4,14 +4,21 @@ source("./R/utilities.R")
 utah_statewide_check_date <- function(url, date = Sys.Date()){
     base_html <- xml2::read_html(url)
     
-    base_html %>%
+    p_headers <- base_html %>%
         rvest::html_nodes("p") %>% 
-        rvest::html_text() %>% 
+        rvest::html_text()
+    
+    ## looking for staff update date
+    ## first look for where on the page this is
+    staff_cases_idx <- p_headers %>%
+        str_which(., "(?i)total confirmed staff cases")
+    
+    ## limit dates that will come up in search results
+    p_headers[c(staff_cases_idx:length(p_headers))] %>%
         {.[str_detect(., "(?i)updated")]} %>% 
         first() %>% 
         str_split("updated") %>% 
         unlist() %>% 
-        {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy() %>%
         error_on_date(date)
 }

--- a/production/scrapers/wisconsin_staff.R
+++ b/production/scrapers/wisconsin_staff.R
@@ -1,14 +1,13 @@
 source("./R/generic_scraper.R")
 source("./R/utilities.R")
 
-wisconsin_staff_check_date <- function(x, date = Sys.Date()){
-    z <- xml2::read_html(x)
-    
-    z %>%
-        rvest::html_node(xpath = "//em[contains(text(),'Updated')]") %>%
+wisconsin_staff_check_date <- function(url, date = Sys.Date()){
+    base_html <- xml2::read_html(url)
+
+    base_html %>%
+        rvest::html_node(xpath = "//em[contains(text(),'updated')]") %>%
         rvest::html_text() %>%
-        str_remove_all("Updated|\\)|\\(|as of") %>%
-        clean_fac_col_txt() %>% 
+        str_remove_all("Last updated on") %>%
         lubridate::mdy() %>%
         error_on_date(date)
 }


### PR DESCRIPTION
This PR is connected to issue https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/339 and https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/351. 

Notable changes:
* To get NYC_jails to work, I had to find a way to address their own broken site. When you click on "CHS COVID-19 Data Snapshot" from [here](https://www.nychealthandhospitals.org/correctionalhealthservices/), it 404 errors. But if you look at the 404 url and change the date to one day earlier, it seems to work. 
* I changed the Nevada scraper class URL to be the powerbi address. As best I can tell, no where in the code is the original url used presently.
* Maryland powerbi, new_york_statewide, north_dakota and oregon have been addressed separately as part of issue https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/340
* Otherwise, I hope the changes are pretty simple/repetitive/easy to review