### PR TITLE
update utah scraper for new way of hosting images

### DIFF
--- a/production/scrapers/utah.R
+++ b/production/scrapers/utah.R
@@ -16,7 +16,7 @@ utah_check_date <- function(x, date = Sys.Date()){
 utah_pull <- function(x){
     get_src_by_attr(x, "img", attr = "src", attr_regex = "(?i)screen-shot") %>%
         .[[1]] %>%
-        str_remove("-[0-9][0-9][0-9]x[0-9][0-9][0-9]") %>%
+        str_remove("-[0-9]+x[0-9]+") %>%
         magick::image_read()
 }
 

--- a/production/scrapers/utah.R
+++ b/production/scrapers/utah.R
@@ -16,6 +16,7 @@ utah_check_date <- function(x, date = Sys.Date()){
 utah_pull <- function(x){
     get_src_by_attr(x, "img", attr = "src", attr_regex = "(?i)screen-shot") %>%
         .[[1]] %>%
+        str_remove("-[0-9][0-9][0-9]x[0-9][0-9][0-9]") %>%
         magick::image_read()
 }
 


### PR DESCRIPTION
before 2021-12-17 all the utah data was about [this size](http://104.131.72.50:3838/scraper_data/raw_files/2021-12-14_utah.png) but starting on [2021-12-17 the images](http://104.131.72.50:3838/scraper_data/raw_files/2021-12-17_utah.png) get way smaller. This is causing extractable to not be able to accurately read the numbers it looks like the change was likely due to a website change in what png is shown the png displayed depends on the attributes of the browser and for some reason our headless browser picks up the smallest sized png here is the link for todays image

https://corrections.utah.gov/wp-content/uploads/2022/01/Screen-Shot-2022-01-05-at-10.29.37-AM-300x158.png

we can easily get a better sized image by just removing the dimensions at the end
https://corrections.utah.gov/wp-content/uploads/2022/01/Screen-Shot-2022-01-05-at-10.29.37-AM.png 

and extracatble gets the numbers correct when its this size.

The fix is implemented in this PR but we will need to do something about the raw and extracted data in our database between 2021-12-17 and 2022-01-11.