### PR TITLE
bugfix: change indexing for pulling raw data from html to pull correct table image

### DIFF
--- a/production/scrapers/michigan_staff.R
+++ b/production/scrapers/michigan_staff.R
@@ -18,11 +18,10 @@ michigan_staff_date_check <- function(x, date = Sys.Date()){
 
 michigan_staff_pull <- function(x){
     mi_html <- xml2::read_html(x)
-    
     img2 <- mi_html %>%
         rvest::html_nodes("img") %>%
         rvest::html_attr("src") %>%
-        .[9] %>%      #src="https://miro.medium.com/max/1210/1*rmlt07ZUHyPh0MkrayUqoA.png"
+        .[7] %>%      #src="https://miro.medium.com/max/1210/1*rmlt07ZUHyPh0MkrayUqoA.png"
         magick::image_read()
     
     img2


### PR DESCRIPTION
Quick fix for the indexing of the HTML in the michigan staff scraper to pull the correct image. 