### PR TITLE
Fix: Add hour minute check to mississippi_date_check

### DIFF
--- a/production/scrapers/mississippi.R
+++ b/production/scrapers/mississippi.R
@@ -19,7 +19,7 @@ mississippi_date_check <- function(url, date = Sys.Date()){
         str_remove("\n") 
         
     date_string %>%
-        lubridate::mdy_h() %>% 
+        lubridate::mdy_hm() %>% 
         lubridate::floor_date(unit = "days") %>%
         lubridate::as_date() %>%
         error_on_date(date)


### PR DESCRIPTION

Closes https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/409

Summary: I think if we use `lubridate::mdy_hm()` instead of `lubridate::mdy_h()`, this will work.