### PR TITLE
Fix: remDr() instead of quit() for compatibility

### DIFF
--- a/production/scrapers/alaska_vaccine.R
+++ b/production/scrapers/alaska_vaccine.R
@@ -21,7 +21,7 @@ alaska_vaccine_check_date <- function(x, date = Sys.Date()){
         str_remove("(?i)as of ") %>%
         lubridate::mdy()
     
-    remDr$quit()
+    remDr$close()
     
     error_on_date(date, site_date)
 }
@@ -35,7 +35,7 @@ alaska_vaccine_pull <- function(x){
     
     base_html <- remDr$getPageSource()
     
-    remDr$quit()
+    remDr$close()
     
     xml2::read_html(base_html[[1]])
 }

--- a/production/scrapers/california.R
+++ b/production/scrapers/california.R
@@ -28,7 +28,7 @@ california_check_date <- function(x, date = Sys.Date()){
         lubridate::floor_date(unit="day") %>%
         as.Date()
     
-    remDr$quit()
+    remDr$close()
     
     error_on_date(site_date, date)
 }
@@ -49,7 +49,7 @@ california_pull <- function(x, wait = 20){
     
     out_html <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     out_html
 }

--- a/production/scrapers/california_statewide.R
+++ b/production/scrapers/california_statewide.R
@@ -18,7 +18,7 @@ california_statewide_check_date <- function(x, date = Sys.Date()){
     
     base_page <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     site_date <- base_page %>%
         rvest::html_nodes("title") %>%
@@ -51,7 +51,7 @@ california_statewide_pull <- function(x, wait = 25){
     
     remDr$screenshot(file = tf)
     
-    remDr$quit()
+    remDr$close()
     
     magick::image_read(tf)
 }

--- a/production/scrapers/california_vaccine_bi.R
+++ b/production/scrapers/california_vaccine_bi.R
@@ -67,7 +67,7 @@ california_vaccine_bi_pull <- function(x, wait = 20){
     
     htmltools::save_html(x, file = tf)
     
-    remDr$quit()
+    remDr$close()
     
     xml2::read_html(tf)
 }

--- a/production/scrapers/colorado.R
+++ b/production/scrapers/colorado.R
@@ -73,7 +73,7 @@ colorado_pull <- function(url){
     }
 
     # Tquit our current selenium instance
-    remDr$quit()
+    remDr$close()
     
     # lets aggregate the files into one readable file,
     # its annoying because they are actually tsvs with weird encodings but 

--- a/production/scrapers/defunct/minnesota.R
+++ b/production/scrapers/defunct/minnesota.R
@@ -25,7 +25,7 @@ minnesota_pull <- function(x, wait = 20){
     
     html_out <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     html_out
 }

--- a/production/scrapers/lasd_staff.R
+++ b/production/scrapers/lasd_staff.R
@@ -15,7 +15,7 @@ lasd_staff_date_check <- function(x, date = Sys.Date()){
     x <- remDr$getPageSource() %>%
         {xml2::read_html(.[[1]])}
     
-    remDr$quit()
+    remDr$close()
     
     rvest::html_nodes(x, ".visualContainer") %>% 
         rvest::html_text() %>% 
@@ -38,7 +38,7 @@ lasd_staff_pull <- function(x, wait = 10){
     out_html <- remDr$getPageSource() %>%
         {xml2::read_html(.[[1]])}
     
-    remDr$quit()
+    remDr$close()
     
     out_html
 }

--- a/production/scrapers/maryland_powerbi.R
+++ b/production/scrapers/maryland_powerbi.R
@@ -16,7 +16,7 @@ maryland_powerbi_pull <- function(x){
     
     base_html <- remDr$getPageSource()
     
-    remDr$quit()
+    remDr$close()
     
     xml2::read_html(base_html[[1]])
 }

--- a/production/scrapers/maryland_vaccine.R
+++ b/production/scrapers/maryland_vaccine.R
@@ -13,7 +13,7 @@ maryland_vaccine_pull <- function(url){
 
     out_html <- xml2::read_html(base_html)
     
-    remDr$quit()
+    remDr$close()
     
     out_html
 }

--- a/production/scrapers/nevada.R
+++ b/production/scrapers/nevada.R
@@ -18,7 +18,7 @@ nevada_check_date <- function(url, date = Sys.Date()){
         {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy()
 
-    remDr$quit()
+    remDr$close()
     
     error_on_date(site_date, date)
 }
@@ -204,7 +204,7 @@ nevada_pull <- function(x){
     
     htmltools::save_html(x, file = tf)
     
-    remDr$quit()
+    remDr$close()
     
     xml2::read_html(tf)
 }

--- a/production/scrapers/north_dakota.R
+++ b/production/scrapers/north_dakota.R
@@ -23,7 +23,7 @@ north_dakota_pull <- function(url){
     raw_html <- remDr$getPageSource() %>%
         {xml2::read_html(.[[1]])}
     
-    remDr$quit()
+    remDr$close()
 
     return(raw_html)
 }

--- a/production/scrapers/oregon.R
+++ b/production/scrapers/oregon.R
@@ -25,7 +25,7 @@ oregon_pull <- function(url){
     raw_html <- remDr$getPageSource() %>%
         {xml2::read_html(.[[1]])}
     
-    remDr$quit()
+    remDr$close()
     
     return(raw_html)
 }

--- a/production/scrapers/pennsylvania_bi_cases.R
+++ b/production/scrapers/pennsylvania_bi_cases.R
@@ -14,7 +14,7 @@ pennsylvania_bi_cases_pull <- function(url, wait = 7){
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
 
-    remDr$quit()
+    remDr$close()
     
     is_covid_cases <- raw_html %>%
         rvest::html_node("h3.preTextWithEllipsis") %>%

--- a/production/scrapers/pennsylvania_bi_deaths.R
+++ b/production/scrapers/pennsylvania_bi_deaths.R
@@ -14,7 +14,7 @@ pennsylvania_bi_deaths_pull <- function(url, wait = 7){
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     is_covid_deaths <- raw_html %>%
         rvest::html_nodes(xpath="//h3[@class='preTextWithEllipsis']") %>%

--- a/production/scrapers/pennsylvania_bi_population.R
+++ b/production/scrapers/pennsylvania_bi_population.R
@@ -14,7 +14,7 @@ pennsylvania_bi_population_pull <- function(url, wait = 7){
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
 
-    remDr$quit()
+    remDr$close()
     
     is_population <- raw_html %>%
         rvest::html_nodes(xpath="//h3[@class='preTextWithEllipsis']") %>%

--- a/production/scrapers/pennsylvania_bi_staff_cases.R
+++ b/production/scrapers/pennsylvania_bi_staff_cases.R
@@ -14,7 +14,7 @@ pennsylvania_bi_staff_cases_pull <- function(url, wait = 7){
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     is_covid_cases <- raw_html %>%
         rvest::html_node("h3.preTextWithEllipsis") %>%

--- a/production/scrapers/pennsylvania_bi_testing.R
+++ b/production/scrapers/pennsylvania_bi_testing.R
@@ -14,7 +14,7 @@ pennsylvania_bi_testing_pull <- function(url, wait = 7){
     
     raw_html <- xml2::read_html(remDr$getPageSource()[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     is_covid_testing <- raw_html %>%
         rvest::html_nodes("h3.preTextWithEllipsis") %>%

--- a/production/scrapers/pennsylvania_bi_vaccination.R
+++ b/production/scrapers/pennsylvania_bi_vaccination.R
@@ -115,7 +115,7 @@ pennsylvania_bi_vaccination_pull <- function(url, wait = 10){
     
     htmltools::save_html(x, file = tf)
     
-    remDr$quit()
+    remDr$close()
     
     xml2::read_html(tf)
 }

--- a/production/scrapers/wisconsin.R
+++ b/production/scrapers/wisconsin.R
@@ -21,7 +21,7 @@ wisconsin_check_date <- function(x, date = Sys.Date()){
     
     base_page <- xml2::read_html(base_html[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     base_page %>%
         rvest::html_node(xpath ="//span[contains(text(),'Updated')]") %>%
@@ -65,7 +65,7 @@ wisconsin_pull <- function(x){
        stop("WI unable to download image")
    }
    
-   remDr$quit()
+   remDr$close()
    
    return(out_file)
    

--- a/production/scrapers/wisconsin_deaths.R
+++ b/production/scrapers/wisconsin_deaths.R
@@ -21,7 +21,7 @@ wisconsin_deaths_check_date <- function(x, date = Sys.Date()){
     
     base_page <- xml2::read_html(base_html[[1]])
     
-    remDr$quit()
+    remDr$close()
     
     base_page %>%
         rvest::html_node(xpath ="//span[contains(text(),'Updated')]") %>%
@@ -67,7 +67,7 @@ wisconsin_deaths_pull <- function(x){
         stop("WI unable to download image")
     }
     
-    remDr$quit()
+    remDr$close()
     
     return(out_file)
 }

--- a/production/scrapers/wisconsin_vaccine.R
+++ b/production/scrapers/wisconsin_vaccine.R
@@ -21,7 +21,7 @@ wisconsin_vaccine_check_date <- function(x, date = Sys.Date()){
 
     base_page <- xml2::read_html(base_html[[1]])
     
-    remDr$quit()
+    remDr$close()
 
     base_page %>%
         rvest::html_node(xpath ="//span[contains(text(),'Updated')]") %>%


### PR DESCRIPTION
Closes [407](https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/407).

The root cause of the issue is that Michael and Hope run Selenium server 3.141.59 and Megan and Lauren run 4.xxx.x. To foster an environment where open source contributions are possible, and to hew to our current strategy of running latest available browser, I believe we should go ahead with swapping out these calls. 

ETA: Hope and Michael, I tagged either of you for review since you're the ones running the older version. I think it would be sufficient to confirm that the swap from quit to close works on one or two scrapers for you locally, rather than run all 20 something. 