### PR TITLE
Fix: change log date calculation to draw from log file name

### DIFF
--- a/reports/post_diagnostics.Rmd
+++ b/reports/post_diagnostics.Rmd
@@ -29,10 +29,14 @@ The table below summarizes the scrapers that yielded errors and warnings. Highli
 new_df <- read_scrape_data(all_dates = FALSE)
 
 # Get all log files from the latest run 
-latest_date <- max(new_df$Date) %>%
-    as.character()
-log_status <- behindbarstools::list_remote_data("log_files") %>% 
-    str_subset(pattern = latest_date) %>% 
+log_files <- behindbarstools::list_remote_data("log_files")
+
+latest_date <- unique(stringr::str_extract(log_files, "\\d+-\\d+-\\d+")) %>%
+    as.Date() %>%
+    max()
+
+log_status <- log_files %>%
+    str_subset(pattern = as.character(latest_date)) %>%
     as_tibble_col(column_name = "log") %>% 
     mutate(scraper = str_extract(log, "(?<=log_files/).*"))%>% 
     mutate(error = map(log, 
@@ -46,7 +50,7 @@ log_status <- behindbarstools::list_remote_data("log_files") %>%
              str_detect(., "(?i)Date is more than 30 different from expected")) %>%
              unlist()
              ) %>%
-  select(-error)
+    select(-error)
 
 # Highlight scrapers with errors   
 kable(log_status %>% 


### PR DESCRIPTION
See [issue 419](https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/419) for full description. This PR makes the date calculation for the "unsuccessful section" of the diagnostic file more reliable.