### PR TITLE
broaden scopes for all gs4_auth calls

### DIFF
--- a/production/historical_scrape/main_historical.R
+++ b/production/historical_scrape/main_historical.R
@@ -7,7 +7,7 @@ suppressPackageStartupMessages(library(tryCatchLog))
 suppressPackageStartupMessages(library(futile.logger))
 # need to explicitly authenticate for this rsession
 suppressPackageStartupMessages(library(googlesheets4))
-gs4_auth("ucla.law.covid.staff@gmail.com")
+gs4_auth("ucla.law.covid.staff@gmail.com", scopes = "https://www.googleapis.com/auth/drive")
 options(tryCatchLog.include.full.call.stack = FALSE)
 source("R/utilities.R")
 

--- a/production/main.R
+++ b/production/main.R
@@ -6,7 +6,7 @@ suppressPackageStartupMessages(library(R6))
 suppressPackageStartupMessages(library(tryCatchLog))
 suppressPackageStartupMessages(library(futile.logger))
 suppressPackageStartupMessages(library(googlesheets4))
-gs4_auth("ucla.law.covid.staff@gmail.com")
+gs4_auth("ucla.law.covid.staff@gmail.com", scopes = "https://www.googleapis.com/auth/drive")
 options(tryCatchLog.include.full.call.stack = FALSE)
 
 parser <- ArgumentParser()

--- a/production/redo_scrape/main_redo.R
+++ b/production/redo_scrape/main_redo.R
@@ -7,7 +7,7 @@ suppressPackageStartupMessages(library(tryCatchLog))
 suppressPackageStartupMessages(library(futile.logger))
 # need to explicitly authenticate for this rsession
 suppressPackageStartupMessages(library(googlesheets4))
-gs4_auth("ucla.law.covid.staff@gmail.com")
+gs4_auth("ucla.law.covid.staff@gmail.com", scopes = "https://www.googleapis.com/auth/drive")
 options(tryCatchLog.include.full.call.stack = FALSE)
 source("R/utilities.R")
 

--- a/production/wayback_scrape/main_wayback.R
+++ b/production/wayback_scrape/main_wayback.R
@@ -7,7 +7,7 @@ suppressPackageStartupMessages(library(tryCatchLog))
 suppressPackageStartupMessages(library(futile.logger))
 # need to explicitly authenticate for this rsession
 suppressPackageStartupMessages(library(googlesheets4))
-gs4_auth("ucla.law.covid.staff@gmail.com")
+gs4_auth("ucla.law.covid.staff@gmail.com", scopes = "https://www.googleapis.com/auth/drive")
 options(tryCatchLog.include.full.call.stack = FALSE)
 source("R/utilities.R")
 # need to explicitly authenticate for this rsession

--- a/reports/post_diagnostics.Rmd
+++ b/reports/post_diagnostics.Rmd
@@ -13,7 +13,7 @@ library(kableExtra)
 library(behindbarstools)
 library(glue)
 library(googlesheets4)
-gs4_auth("ucla.law.covid.staff@gmail.com")
+gs4_auth("ucla.law.covid.staff@gmail.com", scopes = "https://www.googleapis.com/auth/drive")
 ```
 
 ---


### PR DESCRIPTION
Add argument to gs4_auth call to give access to all google drive contents, not just the default spreadsheets. Seems to only solve an issue for me - but seems ok to broaden for everyone. 