### PR TITLE
fix to NV scraper-changed selectors and added comma removal

### DIFF
--- a/production/scrapers/nevada.R
+++ b/production/scrapers/nevada.R
@@ -17,7 +17,7 @@ nevada_check_date <- function(url, date = Sys.Date()){
         unlist() %>%
         {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy()
-    
+
     remDr$close()
     
     error_on_date(site_date, date)
@@ -42,14 +42,14 @@ nevada_pull <- function(x){
     # find the div that has the select all option and see if it is marked
     select_all_ss <- "//span[@title='Select all']/parent::div"
     select_all_node <- remDr$findElement("xpath", select_all_ss)
-    
+
     # if it is marked then we need to unmark it so we can only select
     # correctional facilities
     if(unlist(select_all_node$getElementAttribute("aria-checked")) == "true"){
         select_all_node$clickElement()
         Sys.sleep(10)
     }
-    
+
     # find the correctional facilities tab and mark it
     remDr$findElement(
         "xpath", 
@@ -93,7 +93,7 @@ nevada_pull <- function(x){
         {grepl("^[[:upper:]]+$", .)} %>%
         which()
     
-    
+
     sub_dir <- str_c("./results/raw_files/", Sys.Date(), "_nevada")
     dir.create(sub_dir, showWarnings = FALSE)
     
@@ -217,7 +217,7 @@ nevada_restruct <- function(x){
         str_replace("\\./", "./results/raw_files/")
     
     out.data <- bind_rows(lapply(sub_files, function(hl){
-        
+
         op_page <- xml2::read_html(hl)
         
         facility <- hl %>%
@@ -234,10 +234,7 @@ nevada_restruct <- function(x){
         ## pres /html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[4]/span[2]
         ## ires /html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[7]/span[4]
         ## pstaff /html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[5]/span[1]
-        
-        # /html/body/div[1]/report-embed/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[1]/span[1]
-        # /html/body/div[1]/report-embed/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[2]/span[2]
-        
+
         ## Pull Values and Titles
         residents.confirmed.value <- op_page %>%
             rvest::html_nodes(xpath = str_c(element.front, 2, element.end.value1)) %>%
@@ -389,4 +386,3 @@ if(sys.nframe() == 0){
     nevada$validate_extract()
     nevada$save_extract()
 }
-

--- a/production/scrapers/nevada.R
+++ b/production/scrapers/nevada.R
@@ -17,7 +17,7 @@ nevada_check_date <- function(url, date = Sys.Date()){
         unlist() %>%
         {.[str_detect(., "20")]} %>% # look for year 20xx
         lubridate::mdy()
-
+    
     remDr$close()
     
     error_on_date(site_date, date)
@@ -42,14 +42,14 @@ nevada_pull <- function(x){
     # find the div that has the select all option and see if it is marked
     select_all_ss <- "//span[@title='Select all']/parent::div"
     select_all_node <- remDr$findElement("xpath", select_all_ss)
-
+    
     # if it is marked then we need to unmark it so we can only select
     # correctional facilities
     if(unlist(select_all_node$getElementAttribute("aria-checked")) == "true"){
         select_all_node$clickElement()
         Sys.sleep(10)
     }
-
+    
     # find the correctional facilities tab and mark it
     remDr$findElement(
         "xpath", 
@@ -93,7 +93,7 @@ nevada_pull <- function(x){
         {grepl("^[[:upper:]]+$", .)} %>%
         which()
     
-
+    
     sub_dir <- str_c("./results/raw_files/", Sys.Date(), "_nevada")
     dir.create(sub_dir, showWarnings = FALSE)
     
@@ -217,7 +217,7 @@ nevada_restruct <- function(x){
         str_replace("\\./", "./results/raw_files/")
     
     out.data <- bind_rows(lapply(sub_files, function(hl){
-    
+        
         op_page <- xml2::read_html(hl)
         
         facility <- hl %>%
@@ -225,7 +225,7 @@ nevada_restruct <- function(x){
             unlist() %>%
             last() %>%
             str_remove("\\.html")
-        element.front <- '/html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p['
+        element.front <- '/html/body/div[1]/report-embed/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p['
         element.end.value1 <- ']/span[1]'
         element.end.title.val <- ']/span[2]'
         element.end.title1 <- ']/span[4]'
@@ -235,11 +235,14 @@ nevada_restruct <- function(x){
         ## ires /html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[7]/span[4]
         ## pstaff /html/body/div[1]/root/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[5]/span[1]
         
+        # /html/body/div[1]/report-embed/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[1]/span[1]
+        # /html/body/div[1]/report-embed/div/div/div[1]/div/div/div/exploration-container/div/div/div/exploration-host/div/div/exploration/div/explore-canvas/div/div[2]/div/div[2]/div[2]/visual-container-repeat/visual-container[9]/transform/div/div[3]/div/visual-modern/div/div/div/p[2]/span[2]
         
         ## Pull Values and Titles
         residents.confirmed.value <- op_page %>%
             rvest::html_nodes(xpath = str_c(element.front, 2, element.end.value1)) %>%
             rvest::html_text() %>%
+            str_replace_all(., ',', '') %>%
             as.numeric()
         residents.confirmed.title <- op_page %>%
             rvest::html_nodes(xpath = str_c(element.front, 2, element.end.title.val)) %>%
@@ -301,7 +304,7 @@ nevada_restruct <- function(x){
         
         residents.confirmed.total <- sum(residents.confirmed.value, residents.probable.value, residents.imported.value)
         staff.confirmed.total <- sum(staff.confirmed.value, staff.probable.value)
-    
+        
         tibble(
             Name = facility,
             Residents.Confirmed = residents.confirmed.total,

--- a/production/scrapers/nevada.R
+++ b/production/scrapers/nevada.R
@@ -301,7 +301,7 @@ nevada_restruct <- function(x){
         
         residents.confirmed.total <- sum(residents.confirmed.value, residents.probable.value, residents.imported.value)
         staff.confirmed.total <- sum(staff.confirmed.value, staff.probable.value)
-        
+
         tibble(
             Name = facility,
             Residents.Confirmed = residents.confirmed.total,
@@ -386,3 +386,4 @@ if(sys.nframe() == 0){
     nevada$validate_extract()
     nevada$save_extract()
 }
+

--- a/production/scrapers/nevada.R
+++ b/production/scrapers/nevada.R
@@ -217,7 +217,7 @@ nevada_restruct <- function(x){
         str_replace("\\./", "./results/raw_files/")
     
     out.data <- bind_rows(lapply(sub_files, function(hl){
-
+    
         op_page <- xml2::read_html(hl)
         
         facility <- hl %>%
@@ -301,7 +301,7 @@ nevada_restruct <- function(x){
         
         residents.confirmed.total <- sum(residents.confirmed.value, residents.probable.value, residents.imported.value)
         staff.confirmed.total <- sum(staff.confirmed.value, staff.probable.value)
-
+    
         tibble(
             Name = facility,
             Residents.Confirmed = residents.confirmed.total,

--- a/production/scrapers/nyc_jails.R
+++ b/production/scrapers/nyc_jails.R
@@ -44,7 +44,7 @@ nyc_jails_pull <- function(url){
         as.character()
     
     address_split_on_date <- str_split(address, "\\d{5,}") %>% unlist()
-    
+
     str_c(address_split_on_date[1], new_date, address_split_on_date[2])
 }
 


### PR DESCRIPTION
Proposed fix for the Nevada scraper. Changes involved edits to the selector text wrappers and a new line that strips commas from the `Residents.Confirmed` value because one facility now has values > 1,000 and the `as.numeric` call was converting the value to NA. Just worked locally for me.

I did not attempt to fix the date check error.