### PR TITLE
Change state-wide data src in fac updates function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -842,9 +842,7 @@ track_recent_covid_increases <- function(
   ## define inputs for data filtering
   latest_scrape_date <-  max(scrape_df$Date)
   delta_start_date <- latest_scrape_date - lubridate::days(delta_days)
-  lookaround_delta_start_date <- c(delta_start_date, 
-                                   (delta_start_date + lubridate::days(1)),
-                                    (delta_start_date - lubridate::days(1)))
+
   ## get state-wide data 
   latest_state <- calc_aggregate_counts(state = TRUE, all_dates = FALSE) %>%
     filter(!is.na(Val)) %>%
@@ -853,7 +851,12 @@ track_recent_covid_increases <- function(
     arrange(State) %>%
     select(State, ends_with(c(".Confirmed", ".Deaths", ".Active"))) %>%
     mutate(Date = latest_scrape_date)
-  historical_state <- read_csv("https://raw.githubusercontent.com/uclalawcovid19behindbars/data/master/historical-data/historical_state_counts.csv") %>%
+  historical_state <- read_csv("https://raw.githubusercontent.com/uclalawcovid19behindbars/data/master/historical-data/historical_state_counts.csv") 
+  n_days_closest_deltastart <- as.integer(min(abs(delta_start_date - historical_state$Date)))
+  lookaround_delta_start_date <- c(delta_start_date, 
+                                   (delta_start_date + lubridate::days(n_days_closest_deltastart)),
+                                   (delta_start_date - lubridate::days(n_days_closest_deltastart)))
+  historical_state <- historical_state %>%
     filter(Date %in% lookaround_delta_start_date) %>%
     select(State, ends_with(c(".Confirmed", ".Deaths", ".Active")), Date)
   state_df <- bind_rows(latest_state, historical_state) %>%


### PR DESCRIPTION
Before, we were pulling state-wide counts from the historical state counts dataset on GitHub. That means that if we run the `track_recent_covid_increases` function BEFORE writing the data to GH (our current order of operations), the most recent values will be at least a little bit out of date. I changed the data sources to deal with this. Sorry to create confusion in the way I initially wrote the code!

Closes #421 