### PR TITLE
proposed fix to rhode_island_pdf scraper

### DIFF
--- a/production/scrapers/rhode_island_pdf.R
+++ b/production/scrapers/rhode_island_pdf.R
@@ -16,9 +16,25 @@ rhode_island_pdf_check_date <- function(url, date = Sys.Date()){
 }
 
 rhode_island_pdf_pull <- function(url){
-    pdf_url <- get_src_by_attr(url, "a", attr = "href", 
-                              attr_regex = "ridoc-covid-data")  %>% 
-        first()
+    # Create url front section
+    url_front <- 'https://doc.ri.gov'
+    # Pull pdf link
+    pdf_url <- url %>%
+        read_html() %>%
+        html_nodes('a') %>%
+        html_attr('href') %>%
+        as.data.frame() %>%
+        rename(c('links' = .)) %>%
+        subset(str_detect(links,'media')) %>%
+        mutate(order = str_replace_all(links, '.*media', ''), # Pull order of links from number embedded in download urls
+               order = str_replace_all(order, 'download.*', ''),
+               order = str_replace_all(order, '\\/', ''),
+               order = as.numeric(order)) %>%
+        arrange(desc(order)) %>%
+        first() %>% # Pull highest number / most recent download link
+        .[1, 'links'] %>%
+        str_c(url_front, .)
+    
     return(pdf_url)
 }
 


### PR DESCRIPTION
The `rhode island` DoC website changed such that our old pull_function() no longer selected the proper most recent download link for their COVID pdf. I made changes to the pull_function() to select the correct link. Based off the url structure (which has it's own built-in counter) this should hopefully be resilient. 