### PR TITLE
Michigan image selection, michigan staff data extraction

### DIFF
--- a/production/scrapers/michigan.R
+++ b/production/scrapers/michigan.R
@@ -16,37 +16,27 @@ michigan_date_check <- function(x, date = Sys.Date()){
         error_on_date(date)
 }
 
-michigan_pull <- function(x){
-    mi_html <- xml2::read_html(x)
+michigan_pull <- function(url){
+    mi_html <- xml2::read_html(url)
     
-    imgs <- mi_html %>%
-        rvest::html_nodes("img") %>%
-        rvest::html_attr("src") 
-    Sys.sleep(10)
-    pulled_img <- imgs %>%
-        .[6] %>%    #https://miro.medium.com/max/552/1*4rpmfHDDxmPh23deQ_OGwQ.png 276w, https://miro.medium.com/max/1104/1*4rpmfHDDxmPh23deQ_OGwQ.png 552w, https://miro.medium.com/max/1280/1*4rpmfHDDxmPh23deQ_OGwQ.png 640w, https://miro.medium.com/max/1400/1*4rpmfHDDxmPh23deQ_OGwQ.png 700w
+    data_div <- rvest::html_node(
+        mi_html,
+        xpath = "//h1[contains(text(), 'Total Confirmed Prisoner')]/parent::div")
+
+    resident_image <- rvest::html_nodes(data_div, "img") %>%
+        .[2] %>%
+        rvest::html_attr("src") %>%
         magick::image_read()
     
-    pulled_img
+    return(resident_image)
 }
 
 michigan_restruct <- function(x){
     out_list <- ExtractTable(x)
 
-    # out_list_names <- x %>%
-    #     magick::image_convert(type = "Bilevel") %>%
-    #     # this is finicky and needs to be changed
-    #     # crop out the top row with the column names
-    #     magick::image_crop("1500x80+0+0") %>%
-    #     ExtractTable()
-
-    # names(out_list[[1]]) <- unname(unlist(out_list_names))
-    ## laziest fix if the image crop fails one day
-    ## only do this if you look at the image and it checks out
     names(out_list[[1]]) <- c("Location", "Prisoners Tested", "Total Prisoners Confirmed",
                               "Prisoners Negative", "Active Positive Cases", "Prisoner Deaths")
-
-    out_list
+    return(out_list)
 }
 
 michigan_extract <- function(x){

--- a/production/scrapers/michigan_staff.R
+++ b/production/scrapers/michigan_staff.R
@@ -56,17 +56,16 @@ michigan_staff_extract <- function(restructured_data){
 }
 
 michigan_staff_check_extracted_data <- function(extract_data){
-    if (str_detect(extract_data$Name, "\\d|ocation")) {
+    if (nrow(extract_data %>% 
+             filter(str_detect(Name, "\\d|ocation"))) > 0) {
         warning("Examine Name column for mis-extracted data;
-                numbers or text 'location' found where not expected")
-    }
-    
-    if (str_detect(extract_data$Staff.Confirmed, "[:alpha:]")) {
+            numbers or text 'location' found where not expected")
+    } else if (nrow(extract_data %>% 
+            filter(str_detect(Staff.Confirmed, "[:alpha:]"))) > 0) {
         warning("Examine Staff.Confirmed column for mis-extracted data;
                 alpha characters found where we expect only numerics")
-    }
-    
-    if (str_detect(extract_data$Staff.Deaths, "[:alpha:]")) {
+    } else if (nrow(extract_data %>% 
+            filter(str_detect(Staff.Deaths, "[:alpha:]"))) > 0) {
         warning("Examine Staff.Confirmed column for mis-extracted data;
                 alpha characters found where we expect only numerics")
     }

--- a/production/scrapers/michigan_staff.R
+++ b/production/scrapers/michigan_staff.R
@@ -16,41 +16,60 @@ michigan_staff_date_check <- function(x, date = Sys.Date()){
         error_on_date(date)
 }
 
-michigan_staff_pull <- function(x){
-    mi_html <- xml2::read_html(x)
-    img2 <- mi_html %>%
-        rvest::html_nodes("img") %>%
+michigan_staff_pull <- function(url){
+    mi_html <- xml2::read_html(url)
+
+    data_div <- rvest::html_node(
+        mi_html,
+        xpath = "//h1[contains(text(), 'Total Confirmed Prisoner')]/parent::div")
+
+    staff_image <- rvest::html_nodes(data_div, "img") %>%
+        .[3] %>%
         rvest::html_attr("src") %>%
-        .[7] %>%      #src="https://miro.medium.com/max/1210/1*rmlt07ZUHyPh0MkrayUqoA.png"
-        magick::image_read()
+        magick::image_read() %>%
+        magick::image_crop("0x0+0+40")
 
-    img2
+    return(staff_image)
 }
 
-michigan_staff_restruct <- function(x){
-    ExtractTable(x)
+michigan_staff_restruct <- function(staff_image){
+    table_body <- magick::image_crop(staff_image, "0x0+0+30")
+    
+    staff_data <- ExtractTable(table_body)
+    
+    names(staff_data[[1]]) <- c("Name", "Staff.Confirmed", "Staff.Deaths")
+
+    return(staff_data)
 }
 
-michigan_staff_extract <- function(x){
-    col_name_mat <- matrix(c(
-        "Location", "0", "Name",
-        "Staff confirmed", "1", "Staff.Confirmed",
-        "Staff deaths", "2" , "Staff.Deaths"
-    ), ncol = 3, nrow = 3, byrow = TRUE)
-    
-    colnames(col_name_mat) <- c("check", "raw", "clean")
-    col_name_df <- as_tibble(col_name_mat)
-    
-    check_names_extractable(x[[1]], col_name_df)
-    
-    extract_out <- rename_extractable(x[[1]], col_name_df) %>%
+michigan_staff_extract <- function(restructured_data){
+    extract_data <- restructured_data[[1]] %>%
         as_tibble() %>%
-        filter(Name != "Location" & !grepl(Name, pattern = "Tota")) %>%
+        filter(!grepl(Name, pattern = "Tota")) %>%
         clean_scraped_df() %>%
         mutate(Staff.Deaths = ifelse(is.na(Staff.Deaths), 0, Staff.Deaths),
-               Name = str_remove(Name, "^Location ")) 
+               Name = str_remove(Name, "^Location "))
+
+    michigan_staff_check_extracted_data(extract_data)
+
+    return(extract_data)
+}
+
+michigan_staff_check_extracted_data <- function(extract_data){
+    if (str_detect(extract_data$Name, "\\d|ocation")) {
+        warning("Examine Name column for mis-extracted data;
+                numbers or text 'location' found where not expected")
+    }
     
-    return(extract_out)
+    if (str_detect(extract_data$Staff.Confirmed, "[:alpha:]")) {
+        warning("Examine Staff.Confirmed column for mis-extracted data;
+                alpha characters found where we expect only numerics")
+    }
+    
+    if (str_detect(extract_data$Staff.Deaths, "[:alpha:]")) {
+        warning("Examine Staff.Confirmed column for mis-extracted data;
+                alpha characters found where we expect only numerics")
+    }
 }
 
 #' Scraper class for general Michigan staff COVID data


### PR DESCRIPTION
Closes [issue 434](https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/434) and [issue 416](https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/issues/416)

I think it's worth noting that I shifted to a much more hard-coded strategy in the Michigan staff scraper. I did try a couple image read strategies -- splitting the image into a header row and a table row and reading each separately, sharpening, black and white-ing the imeages, but I just could not get the header row to read in consistently. Given that we've similarly hard-coded the Michigan scraper, it felt more reliable to me to just hard-code and add some data checks. 
